### PR TITLE
feat: zap up — update command with --latest, --recursive and --interactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ zap --help
 | `zap run`     | `r`                   | Run a script defined in package.json                   | ✅       |
 | `zap rebuild` | `rb`                  | Rebuild installed native node addons                   | ✅       |
 | `zap exec`    | `e`                   | Execute a shell command in the scope of the project    | ✅       |
-| `zap update`  | `up` `upgrade`        | Update the lockfile with the newest package versions   | ⏳ _WIP_ |
+| `zap update`  | `up` `upgrade`        | Update dependencies                                    | ✅ |
 | `zap why`     | `y`                   | Show information about why a package is installed      | ✅       |
 
 #### Check the [project board](https://github.com/users/elbywan/projects/1/views/1) for the current status of the project.
@@ -128,6 +128,21 @@ zap -r test
 zap -F "my_app^..." --deferred-output run build
 # Disregard the topological ordering and run the scripts in parallel.
 zap run --parallel -r build
+```
+
+- **Dependency updates**
+
+```bash
+# Update everything within declared ranges
+zap up
+# Bump direct dependencies to their latest version, rewriting package.json
+zap up --latest
+# Re-resolve transitive dependencies too
+zap up --latest --recursive
+# Update specific packages, optionally to a range
+zap up react react-dom@^18.0.0
+# Pick packages interactively (/ searches, f filters by bump severity)
+zap up --interactive
 ```
 
 - **[Private registries](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc#auth-related-configuration)**

--- a/packages/cli/shard.lock
+++ b/packages/cli/shard.lock
@@ -56,9 +56,9 @@ shards:
     path: ../store
     version: 0.0.1
 
-  term-cursor:
-    git: https://github.com/crystal-term/cursor.git
-    version: 0.1.0+git.commit.8805d5f686d153db92cf2ce3333433f8ed3708d0
+  tui:
+    path: ../tui
+    version: 0.1.3
 
   utils:
     path: ../utils

--- a/packages/cli/zap.cr
+++ b/packages/cli/zap.cr
@@ -20,7 +20,7 @@ require "commands/why/cli"
 require "commands/why"
 
 module Zap
-  Colorize.on_tty_only!
+  # Colorize is tty-only by default since Crystal 1.17; no explicit call needed.
   Zap.run
 
   VERSION = {{ `shards version`.stringify }}.chomp

--- a/packages/commands/install/cli.cr
+++ b/packages/commands/install/cli.cr
@@ -63,6 +63,9 @@ class Commands::Install::CLI < Commands::CLI
       Helpers.flag("--recursive", "Also re-resolve transitive dependencies, not only direct ones. #{"[env: ZAP_INSTALL_UPDATE_RECURSIVE]".colorize.dim}") do
         command_config.ref = install_config.copy_with(update_recursive: true)
       end
+      Helpers.flag("--interactive", "Show a list of updateable packages and pick which ones to upgrade.") do
+        command_config.ref = install_config.copy_with(interactive: true)
+      end
     end
 
     Helpers.subSeparator("Strategies")
@@ -125,6 +128,9 @@ class Commands::Install::CLI < Commands::CLI
       if remove_packages
         install_config.removed_packages.concat(pkgs)
       elsif update_packages
+        if install_config.interactive && pkgs.size > 0
+          raise "Cannot combine package arguments with --interactive: the packages to upgrade are picked from the list."
+        end
         command_config.ref = install_config.copy_with(update_all: pkgs.size == 0)
         install_config.updated_packages.concat(pkgs)
       else

--- a/packages/commands/install/cli.cr
+++ b/packages/commands/install/cli.cr
@@ -55,6 +55,15 @@ class Commands::Install::CLI < Commands::CLI
     Helpers.flag("--workers <nb_of_workers>", "Set the number of worker threads to use. #{"[env: ZAP_WORKERS]".colorize.dim}") do |nb_of_workers|
       command_config.ref = install_config.copy_with(workers: nb_of_workers.to_i32)
     end
+    if update_packages
+      # Flags specific to the update command (zap up / zap update / zap upgrade)
+      Helpers.flag("--latest", "Bump direct dependencies outside their declared range and rewrite the package.json specifier (preserving ^, ~, <=, >= and exact). #{"[env: ZAP_INSTALL_UPDATE_LATEST]".colorize.dim}") do
+        command_config.ref = install_config.copy_with(update_latest: true)
+      end
+      Helpers.flag("--recursive", "Also re-resolve transitive dependencies, not only direct ones. #{"[env: ZAP_INSTALL_UPDATE_RECURSIVE]".colorize.dim}") do
+        command_config.ref = install_config.copy_with(update_recursive: true)
+      end
+    end
 
     Helpers.subSeparator("Strategies")
 

--- a/packages/commands/install/config.cr
+++ b/packages/commands/install/config.cr
@@ -32,6 +32,9 @@ struct Commands::Install::Config < Core::CommandConfig
   # busting the lockfile cache for direct dependencies
   @[Env]
   getter update_recursive : Bool = false
+  # --interactive: let the user pick the packages to update from a list
+  # (requires a TTY, hence no env var)
+  getter interactive : Bool = false
   @[Env]
   getter save : Bool = true
   @[Env]

--- a/packages/commands/install/config.cr
+++ b/packages/commands/install/config.cr
@@ -24,8 +24,14 @@ struct Commands::Install::Config < Core::CommandConfig
   getter updated_packages : Array(String) = Array(String).new
   @[Env]
   getter update_all : Bool = false
+  # --latest: bump direct dependencies outside their declared range, rewriting
+  # the package.json specifier while preserving the range modifier
   @[Env]
-  getter update_to_latest : Bool = false
+  getter update_latest : Bool = false
+  # --recursive: also re-resolve transitive dependencies instead of only
+  # busting the lockfile cache for direct dependencies
+  @[Env]
+  getter update_recursive : Bool = false
   @[Env]
   getter save : Bool = true
   @[Env]

--- a/packages/commands/install/install.cr
+++ b/packages/commands/install/install.cr
@@ -10,6 +10,7 @@ require "utils/shasum"
 require "./config"
 require "./state"
 require "./resolver"
+require "./interactive"
 require "./linker"
 require "./linker/classic"
 require "./linker/isolated"
@@ -97,6 +98,11 @@ module Commands::Install
 
       # Remove packages if specified from the CLI
       remove_packages(state)
+
+      # Interactive update: let the user pick the packages to upgrade
+      if state.install_config.interactive
+        state = Commands::Install::Interactive.run(state)
+      end
 
       # Resolve all dependencies
       update_changed = resolve_dependencies(state)

--- a/packages/commands/install/install.cr
+++ b/packages/commands/install/install.cr
@@ -99,7 +99,7 @@ module Commands::Install
       remove_packages(state)
 
       # Resolve all dependencies
-      resolve_dependencies(state)
+      update_changed = resolve_dependencies(state)
 
       # Prune lockfile before installing to cleanup pinned dependencies
       pruned_direct_dependencies = clean_lockfile(state)
@@ -135,7 +135,7 @@ module Commands::Install
         state.lockfile.write(format: config.lockfile_format)
 
         # Edit and write the package.json files if the flags have been set in the config
-        write_package_json_files(state)
+        write_package_json_files(state, update_changed)
       end
 
       # Install dependencies to the appropriate node_modules folder
@@ -307,15 +307,17 @@ module Commands::Install
       end
       Log.debug { "• Resolving dependencies" }
       # Resolve and store dependencies
-      state.context.scope_packages(:install).each do |package|
-        Resolver.resolve_dependencies_of(
-          package,
-          state: state,
-          disable_cache_for_packages: state.install_config.updated_packages,
-          disable_cache: state.install_config.update_all
-        )
+      update_changed = state.context.scope_packages(:install).reduce(false) do |acc, package|
+        # Note: the call must always run (it mutates the lockfile), so the
+        # accumulated value is OR'd after it, never short-circuited.
+        Resolver.resolve_dependencies_of(package, state: state) || acc
       end
       state.pipeline.await
+      # Rewrite direct dependency specifiers when --latest bumped them
+      update_changed = state.context.scope_packages(:install).reduce(update_changed) do |acc, package|
+        Resolver.rewrite_latest_specifiers(package, state) || acc
+      end
+      update_changed
     end
   end
 
@@ -369,29 +371,43 @@ module Commands::Install
     pruned_dependencies
   end
 
-  private def self.write_package_json_files(state : State)
+  private def self.write_package_json_files(state : State, update_changed : Bool = false)
     Log.debug { "• Writing package.json file(s)" }
-    if state.install_config.added_packages.size > 0 || state.install_config.removed_packages.size > 0
-      [*state.context.scope_packages_and_paths(:command)].each do |package, location|
+    if state.install_config.added_packages.size > 0 || state.install_config.removed_packages.size > 0 || update_changed
+      # Adds/removes mutate the command scope; updates mutate the install
+      # scope (all workspaces), which the command scope does not cover.
+      packages_to_write =
+        if update_changed && (state.install_config.added_packages.size > 0 || state.install_config.removed_packages.size > 0)
+          (state.context.scope_packages_and_paths(:command) + state.context.scope_packages_and_paths(:install)).uniq
+        elsif update_changed
+          state.context.scope_packages_and_paths(:install)
+        else
+          state.context.scope_packages_and_paths(:command)
+        end
+      packages_to_write.each do |package, location|
         package_json = JSON.parse(File.read(Path.new(location).join("package.json"))).as_h
         if (deps = package.dependencies) && deps.size > 0
-          package_json["dependencies"] = JSON::Any.new(deps.transform_values { |v| JSON::Any.new(v.as(String)) })
+          package_json["dependencies"] = JSON::Any.new(deps.transform_values { |v| JSON::Any.new(v.is_a?(Data::Package::Alias) ? v.to_s : v.as(String)) })
         else
           package_json.delete("dependencies")
         end
         if (dev_deps = package.dev_dependencies) && dev_deps.size > 0
-          package_json["devDependencies"] = JSON::Any.new(dev_deps.transform_values { |v| JSON::Any.new(v.as(String)) })
+          package_json["devDependencies"] = JSON::Any.new(dev_deps.transform_values { |v| JSON::Any.new(v.is_a?(Data::Package::Alias) ? v.to_s : v.as(String)) })
         else
           package_json.delete("devDependencies")
         end
         if (opt_deps = package.optional_dependencies) && opt_deps.size > 0
-          package_json["optionalDependencies"] = JSON::Any.new(opt_deps.transform_values { |v| JSON::Any.new(v.as(String)) })
+          package_json["optionalDependencies"] = JSON::Any.new(opt_deps.transform_values { |v| JSON::Any.new(v.is_a?(Data::Package::Alias) ? v.to_s : v.as(String)) })
         else
           package_json.delete("optionalDependencies")
         end
         File.write(Path.new(location).join("package.json"), package_json.to_pretty_json)
       end
     end
+  end
+
+  private def self.json_specifier(specifier : String | Data::Package::Alias) : JSON::Any
+    JSON::Any.new(specifier.is_a?(Data::Package::Alias) ? specifier.to_s : specifier)
   end
 
   private def self.check_engines(state : State) : Nil

--- a/packages/commands/install/interactive.cr
+++ b/packages/commands/install/interactive.cr
@@ -1,0 +1,135 @@
+require "tui"
+require "semver"
+require "shared/constants"
+require "./manifest"
+require "./state"
+
+module Commands::Install
+  # `zap up --interactive`: scans the direct dependencies for available
+  # upgrades and lets the user pick which ones to re-resolve.
+  module Interactive
+    Log = ::Log.for("zap.commands.install.interactive")
+
+    # A direct dependency that can be upgraded: the target is the newest
+    # version satisfying the declared range (yarn upgrade-interactive parity).
+    record Updateable, name : String, current : String, target : String, range : String
+
+    # Runs the interactive selection and returns the state with the chosen
+    # packages queued for update. A cancelled or empty selection is a no-op.
+    def self.run(state : State) : State
+      unless STDIN.tty? && STDOUT.tty?
+        raise "The --interactive flag requires a terminal (TTY)."
+      end
+      updateable = scan(state)
+      if updateable.empty?
+        state.reporter.info("Everything is up to date!")
+        return with_config(state, state.install_config.copy_with(update_all: false))
+      end
+
+      items = updateable.map { |u|
+        color = bump_color(u.current, u.target)
+        # Colored bump square, plain name, the current (dimmed) then the
+        # target in bold + bump color: the version you get is the eye-catcher.
+        Tui::List::Item.new(
+          label: "#{color}■#{Tui::Ansi::RESET} #{u.name}  #{Tui::Ansi::DIM}#{u.current} →#{Tui::Ansi::RESET} #{Tui::Ansi::BOLD}#{color}#{u.target}#{Tui::Ansi::RESET}",
+        )
+      }
+      input = Tui::Input.new
+      selected = input.raw do
+        Tui::List.select(items, input)
+      end
+      names = selected.map { |index| updateable[index].name }
+      # The list targets match the apply: in-range by default, or the latest
+      # (with the manifest rewrite) when --latest is also set.
+      with_config(state, state.install_config.copy_with(update_all: false, updated_packages: names))
+    end
+
+    # The color of the version arrow, by bump severity: red for a major bump,
+    # yellow for a minor, green for a patch.
+    def self.bump_color(current : String, target : String) : String
+      current_version = Semver::Version.parse(current)
+      target_version = Semver::Version.parse(target)
+      if current_version.major != target_version.major
+        Tui::Ansi::RED
+      elsif current_version.minor != target_version.minor
+        Tui::Ansi::YELLOW
+      else
+        Tui::Ansi::GREEN
+      end
+    end
+
+    # Returns the state with a different install config.
+    private def self.with_config(state : State, config : Config) : State
+      State.new(
+        config: state.config,
+        install_config: config,
+        store: state.store,
+        main_package: state.main_package,
+        lockfile: state.lockfile,
+        context: state.context,
+        npmrc: state.npmrc,
+        registry_clients: state.registry_clients,
+        pipeline: state.pipeline,
+        reporter: state.reporter
+      )
+    end
+
+    # Scans the direct dependencies of the command scope and returns the ones
+    # for which a newer version is available within the declared range.
+    def self.scan(state : State) : Array(Updateable)
+      # The scan is silent: the list appears on its own screen afterwards, so
+      # no progress is rendered (nothing is shown until the user can choose).
+      result = Concurrency::SafeArray(Updateable).new
+      each_direct_dependency(state) do |package, name, declared|
+        state.pipeline.process do
+          begin
+            range = Semver.parse(declared)
+            if state.install_config.update_latest && Utils::Misc.latest_eligible_specifier?(declared)
+              range = Semver.parse("*")
+            end
+            if target = newest_satisfying(state, name, range)
+              current = state.lockfile.roots[package.name]?.try(&.dependency_specifier?(name))
+              if current.is_a?(String) && target != current && Semver::Version.parse(target) > Semver::Version.parse(current)
+                result << Updateable.new(name: name, current: current, target: target, range: declared)
+              end
+            end
+          rescue ex
+            # Unreachable registry or unparseable version: skip the package.
+            Log.debug { "(#{name}) Skipped during interactive scan: #{ex.message}" }
+          end
+        end
+      end
+      state.pipeline.await
+      result.inner.sort_by!(&.name)
+    end
+
+    # Yields every registry-backed direct dependency of the command scope.
+    private def self.each_direct_dependency(state : State, &block : (Data::Package, String, String) -> Nil)
+      state.context.scope_packages(:command).each do |package|
+        package.each_dependency(include_dev: true, include_optional: true) do |name, declared, _type|
+          next unless declared.is_a?(String)
+          # Only registry ranges are comparable; git/workspace/tarball
+          # specifiers and dist-tags are left out of the list.
+          next unless Semver.parse?(declared)
+          block.call(package, name, declared)
+        end
+      end
+    end
+
+    # The newest version of *name* satisfying the range, or nil when the
+    # registry is unreachable.
+    private def self.newest_satisfying(state : State, name : String, range : Semver::Range) : String?
+      base_url = URI.parse(state.npmrc.registry)
+      if name.starts_with?('@')
+        scope = name.split('/')[0]
+        if scoped = state.npmrc.scoped_registries[scope]?
+          base_url = URI.parse(scoped)
+        end
+      end
+      metadata_url = base_url.relativize("/#{name}").to_s
+      manifest = state.registry_clients.get_or_init_pool(base_url.to_s)
+        .fetch_with_cache(metadata_url, Shared::Constants::HEADERS) { |body| Manifest.new(body) }
+      manifest.get_raw_metadata?(range).try { |raw| Data::Package.from_json(raw).version }
+    end
+  end
+end

--- a/packages/commands/install/interactive.cr
+++ b/packages/commands/install/interactive.cr
@@ -12,7 +12,7 @@ module Commands::Install
 
     # A direct dependency that can be upgraded: the target is the newest
     # version satisfying the declared range (yarn upgrade-interactive parity).
-    record Updateable, name : String, current : String, target : String, range : String
+    record Updateable, name : String, current : String, target : String
 
     # Runs the interactive selection and returns the state with the chosen
     # packages queued for update. A cancelled or empty selection is a no-op.
@@ -32,6 +32,7 @@ module Commands::Install
         # target in bold + bump color: the version you get is the eye-catcher.
         Tui::List::Item.new(
           label: "#{color}■#{Tui::Ansi::RESET} #{u.name}  #{Tui::Ansi::DIM}#{u.current} →#{Tui::Ansi::RESET} #{Tui::Ansi::BOLD}#{color}#{u.target}#{Tui::Ansi::RESET}",
+          tag: bump_type(u.current, u.target),
         )
       }
       input = Tui::Input.new
@@ -44,17 +45,27 @@ module Commands::Install
       with_config(state, state.install_config.copy_with(update_all: false, updated_packages: names))
     end
 
-    # The color of the version arrow, by bump severity: red for a major bump,
-    # yellow for a minor, green for a patch.
-    def self.bump_color(current : String, target : String) : String
+    # The bump class of a version jump, used to color the arrow and as the
+    # list's filter tag.
+    def self.bump_type(current : String, target : String) : String
       current_version = Semver::Version.parse(current)
       target_version = Semver::Version.parse(target)
       if current_version.major != target_version.major
-        Tui::Ansi::RED
+        "major"
       elsif current_version.minor != target_version.minor
-        Tui::Ansi::YELLOW
+        "minor"
       else
-        Tui::Ansi::GREEN
+        "patch"
+      end
+    end
+
+    # The color of the version arrow, by bump severity: red for a major bump,
+    # yellow for a minor, green for a patch.
+    def self.bump_color(current : String, target : String) : String
+      case bump_type(current, target)
+      when "major" then Tui::Ansi::RED
+      when "minor" then Tui::Ansi::YELLOW
+      else              Tui::Ansi::GREEN
       end
     end
 
@@ -90,7 +101,7 @@ module Commands::Install
             if target = newest_satisfying(state, name, range)
               current = state.lockfile.roots[package.name]?.try(&.dependency_specifier?(name))
               if current.is_a?(String) && target != current && Semver::Version.parse(target) > Semver::Version.parse(current)
-                result << Updateable.new(name: name, current: current, target: target, range: declared)
+                result << Updateable.new(name: name, current: current, target: target)
               end
             end
           rescue ex
@@ -100,12 +111,13 @@ module Commands::Install
         end
       end
       state.pipeline.await
-      result.inner.sort_by!(&.name)
+      result.inner.sort_by!(&.name).uniq(&.name)
     end
 
-    # Yields every registry-backed direct dependency of the command scope.
+    # Yields every registry-backed direct dependency of every workspace (the
+    # install scope), deduplicated by package name in the scan.
     private def self.each_direct_dependency(state : State, &block : (Data::Package, String, String) -> Nil)
-      state.context.scope_packages(:command).each do |package|
+      state.context.scope_packages(:install).each do |package|
         package.each_dependency(include_dev: true, include_optional: true) do |name, declared, _type|
           next unless declared.is_a?(String)
           # Only registry ranges are comparable; git/workspace/tarball

--- a/packages/commands/install/interactive.cr
+++ b/packages/commands/install/interactive.cr
@@ -88,6 +88,13 @@ module Commands::Install
     # Scans the direct dependencies of the command scope and returns the ones
     # for which a newer version is available within the declared range.
     def self.scan(state : State) : Array(Updateable)
+      # The list's "current version" comes from the lockfile. Without it the
+      # scan would fetch every latest version and then report nothing to
+      # update: fail fast instead of leaving the user staring at an empty
+      # screen for minutes.
+      unless state.lockfile.read_status.from_disk?
+        raise "The interactive list needs a lockfile to know the current versions. Run `zap i` first, then `zap up --interactive`."
+      end
       # The scan is silent: the list appears on its own screen afterwards, so
       # no progress is rendered (nothing is shown until the user can choose).
       result = Concurrency::SafeArray(Updateable).new

--- a/packages/commands/install/linker/classic/writer/file.cr
+++ b/packages/commands/install/linker/classic/writer/file.cr
@@ -21,7 +21,7 @@ class Commands::Install::Linker::Classic
       install_folder = aliased_name || dependency.name
       target_path = location.value.node_modules / install_folder
       install_location = self.class.init_location(dependency, target_path, location)
-      exists = ::File.symlink?(target_path) && ::File.realpath(target_path) == link_source.to_s
+      exists = ::File.symlink?(target_path) && ::File.realpath(target_path) == ::File.realpath(link_source)
       if exists
         {install_location, false}
       else

--- a/packages/commands/install/linker/classic/writer/workspace.cr
+++ b/packages/commands/install/linker/classic/writer/workspace.cr
@@ -8,7 +8,7 @@ class Commands::Install::Linker::Classic
       link_source = workspace.path
       install_folder = aliased_name || dependency.name
       target_path = location.value.node_modules / install_folder
-      exists = ::File.symlink?(target_path) && ::File.realpath(target_path) == link_source.to_s
+      exists = ::File.symlink?(target_path) && ::File.realpath(target_path) == ::File.realpath(link_source)
       if exists
         {nil, false}
       else

--- a/packages/commands/install/protocol/alias/alias.cr
+++ b/packages/commands/install/protocol/alias/alias.cr
@@ -48,6 +48,9 @@ struct Commands::Install::Protocol::Alias < Commands::Install::Protocol::Base
       end
     }
 
-    Registry::Resolver.new(state, Aliased.new(name: package_name, alias: name), final_specifier, parent, dependency_type, skip_cache)
+    # --latest applies to aliases too: the aliased specifier's eligibility
+    # is computed the same way as a plain registry dependency.
+    latest_eligible = package_specifier.try { |s| Utils::Misc.latest_eligible_specifier?(s) } || false
+    Registry::Resolver.new(state, Aliased.new(name: package_name, alias: name), final_specifier, parent, dependency_type, skip_cache, latest_eligible)
   end
 end

--- a/packages/commands/install/protocol/registry/registry.cr
+++ b/packages/commands/install/protocol/registry/registry.cr
@@ -28,6 +28,13 @@ struct Commands::Install::Protocol::Registry < Commands::Install::Protocol::Base
     Log.debug { "(#{name}@#{specifier}) Resolved as a registry dependency" }
     semver = Semver.parse?(specifier)
     Log.debug { "(#{name}@#{specifier}) Failed to parse semver '#{specifier}', treating as a dist-tag." } unless semver
-    Resolver.new(state, name, semver || specifier, parent, dependency_type, skip_cache)
+    # --latest may only ignore the declared range when it is a simple
+    # rewritable form (^, ~, <=, >=, exact); complex ranges stay in-range and
+    # prerelease-carrying specifiers keep their range so a beta is never
+    # downgraded.
+    latest_eligible = !specifier.includes?("-") &&
+      (specifier.starts_with?("^") || specifier.starts_with?("~") ||
+       !!specifier.matches?(/\A(<=|>=)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/))
+    Resolver.new(state, name, semver || specifier, parent, dependency_type, skip_cache, latest_eligible)
   end
 end

--- a/packages/commands/install/protocol/registry/registry.cr
+++ b/packages/commands/install/protocol/registry/registry.cr
@@ -32,9 +32,7 @@ struct Commands::Install::Protocol::Registry < Commands::Install::Protocol::Base
     # rewritable form (^, ~, <=, >=, exact); complex ranges stay in-range and
     # prerelease-carrying specifiers keep their range so a beta is never
     # downgraded.
-    latest_eligible = !specifier.includes?("-") &&
-      (specifier.starts_with?("^") || specifier.starts_with?("~") ||
-       !!specifier.matches?(/\A(<=|>=)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/))
+    latest_eligible = Utils::Misc.latest_eligible_specifier?(specifier)
     Resolver.new(state, name, semver || specifier, parent, dependency_type, skip_cache, latest_eligible)
   end
 end

--- a/packages/commands/install/protocol/registry/resolver.cr
+++ b/packages/commands/install/protocol/registry/resolver.cr
@@ -24,8 +24,9 @@ struct Commands::Install::Protocol::Registry::Resolver < Commands::Install::Prot
     parent = nil,
     dependency_type = nil,
     skip_cache = false,
+    @latest_eligible : Bool = false,
   )
-    super
+    super(state, name, specifier, parent, dependency_type, skip_cache)
 
     package_name = name.is_a?(Aliased) ? name.name : name
     return nil if package_name.nil?
@@ -145,7 +146,20 @@ struct Commands::Install::Protocol::Registry::Resolver < Commands::Install::Prot
         Manifest.new(http.get(metadata_url, Shared::Constants::HEADERS).body)
       } : @client_pool.fetch_with_cache(metadata_url, Shared::Constants::HEADERS) { |body| Manifest.new(body) }
       Log.debug { "(#{@name}@#{@specifier}) Checking the registry metadata for a match against the version/dist-tag" }
-      raw_metadata = manifest.get_raw_metadata?(pinned_version ? Semver.parse(pinned_version) : self.specifier)
+      # With --latest the declared range is ignored and the newest version is
+      # picked; the resolved version is still pinned to the lockfile. Only
+      # direct dependencies (parent: the lockfile root) and overrides (no
+      # parent) qualify: transitives always stay within their declared range,
+      # even when combined with --recursive.
+      version_for_selection =
+        if @latest_eligible && state.install_config.update_latest && (state.install_config.update_all || state.install_config.updated_packages.size > 0) && (@parent.nil? || @parent.is_a?(Data::Lockfile::Root))
+          Semver.parse("*")
+        elsif pinned_version
+          Semver.parse(pinned_version)
+        else
+          self.specifier
+        end
+      raw_metadata = manifest.get_raw_metadata?(version_for_selection)
       unless raw_metadata
         raise "No version matching range or dist-tag #{specifier} for package #{@name} found in the module registry"
       end

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -66,10 +66,10 @@ module Commands::Install::Resolver
       # Bust the lockfile cache for the packages being updated. With
       # --recursive the whole transitive tree under a matched package is
       # re-resolved too (an ancestor match propagates the bust downwards).
-      bust_pinned_cache = (is_root || config.update_recursive) && (config.update_all || config.updated_packages.any? do |pattern|
+      bust_pinned_cache = (is_root || config.update_recursive) && (config.update_all || update_target?(config.updated_packages, name) || (config.update_recursive && config.updated_packages.any? do |pattern|
         name_pattern, _range = Utils::Misc.parse_key(pattern)
-        ::File.match?(name_pattern, name) || (config.update_recursive && ancestors.any? { |a| ::File.match?(name_pattern, a.name) })
-      end)
+        !name_pattern.starts_with?('!') && ancestors.any? { |a| ::File.match?(name_pattern, a.name) }
+      end))
 
       if version_or_alias.is_a?(Data::Package::Alias)
         version = version_or_alias.to_s
@@ -89,6 +89,26 @@ module Commands::Install::Resolver
       )
     end
     changed
+  end
+
+  # Whether a dependency is targeted by the update patterns (pnpm parity):
+  # a leading "!" negates a pattern and excludes a matching package, mixed
+  # patterns only target their positive matches, and negation-only patterns
+  # target everything else.
+  private def self.update_target?(patterns : Array(String), name : String) : Bool
+    return false if patterns.empty?
+    has_positive = false
+    positive_match = false
+    patterns.each do |pattern|
+      name_pattern, _range = Utils::Misc.parse_key(pattern)
+      if name_pattern.starts_with?('!')
+        return false if ::File.match?(name_pattern[1..], name)
+      else
+        has_positive = true
+        positive_match = true if ::File.match?(name_pattern, name)
+      end
+    end
+    !has_positive || positive_match
   end
 
   # Applies `zap up pkg@<range>` arguments: the declared specifier of the
@@ -133,13 +153,22 @@ module Commands::Install::Resolver
     package.each_dependency_hash(include_dev: true, include_optional: true) do |deps, type|
       next unless deps
       deps.each do |name, declared|
-        next unless declared.is_a?(String)
         # Only touch the packages actually being updated; pins and declared
         # ranges always differ, so a pin comparison alone is not enough.
-        next unless config.update_all || config.updated_packages.any? do |pattern|
-          name_pattern, _range = Utils::Misc.parse_key(pattern)
-          ::File.match?(name_pattern, name)
+        next unless config.update_all || update_target?(config.updated_packages, name)
+        if alias_info = alias_specifier(declared)
+          # npm: aliases: preserve the modifier and bump the aliased version.
+          resolved = state.lockfile.roots[package.name]?.try(&.dependency_specifier?(name))
+          resolved_version = resolved.is_a?(Data::Package::Alias) ? resolved.version : (resolved.is_a?(String) ? alias_specifier(resolved).try(&.[1]) : nil)
+          if resolved_version && (modifier = range_modifier(alias_info[1]))
+            new_version = "#{modifier}#{resolved_version}"
+            next if new_version == alias_info[1]
+            package.dependency_specifier(name, Data::Package::Alias.new(alias_info[0], new_version), type)
+            changed = true
+          end
+          next
         end
+        next unless declared.is_a?(String)
         resolved = state.lockfile.roots[package.name]?.try(&.dependency_specifier?(name))
         next unless resolved
         if modifier = range_modifier(declared)
@@ -151,6 +180,17 @@ module Commands::Install::Resolver
       end
     end
     changed
+  end
+
+  # For npm: aliases (either an Alias record or a "npm:name@spec" string),
+  # returns {aliased_name, aliased_specifier}.
+  private def self.alias_specifier(declared : String | Data::Package::Alias) : {String, String}?
+    if declared.is_a?(Data::Package::Alias)
+      {declared.name, declared.version}
+    elsif declared.starts_with?("npm:")
+      name, spec = Utils::Misc.parse_key(declared[4..])
+      {name, spec || "latest"}
+    end
   end
 
   private def self.range_modifier(declared : String) : String?

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -303,8 +303,11 @@ module Commands::Install::Resolver
         _metadata.dependents << package if package
 
         # Mutate only if the package is not already in the lockfile, or when
-        # an update re-resolved it (so the refreshed dependency pins persist)
-        if !lockfile_metadata || forced_retrieval || state.install_config.update_recursive
+        # an update re-resolved it for the first time in this run. The
+        # dependency pins are written after this store (as the children
+        # resolve), so re-storing a fresh manifest on a later visit would
+        # wipe them and replace them with the declared ranges.
+        if !lockfile_metadata || forced_retrieval || (state.install_config.update_recursive && !already_resolved)
           Log.debug { "(#{metadata_key}) Saving package metadata in the lockfile #{(package ? "[parent: #{package.key}]" : "")}" }
           # Remove dev dependencies
           _metadata.dev_dependencies = nil

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -43,10 +43,14 @@ module Commands::Install::Resolver
     *,
     state : Commands::Install::State,
     ancestors : Deque(Data::Package) = Deque(Data::Package).new,
-    disable_cache_for_packages : Array(String)? = nil,
-    disable_cache : Bool = false,
   )
     is_root = ancestors.size == 0
+    config = state.install_config
+
+    # zap up pkg@<range>: write the requested range into the manifest first,
+    # so the dependency resolves (and saves) against it.
+    changed = is_root && config.updated_packages.size > 0 ? apply_updated_ranges(package, config) : false
+
     package.each_dependency(
       include_dev: is_root,
       include_optional: true
@@ -59,11 +63,12 @@ module Commands::Install::Resolver
         end
       end
 
-      # Check if the package is in the no_cache_packages set and bust the lockfile cache if needed
-      bust_pinned_cache = is_root && (disable_cache || begin
-        disable_cache_for_packages.try &.any? do |pattern|
-          ::File.match?(pattern, name)
-        end || false
+      # Bust the lockfile cache for the packages being updated. With
+      # --recursive the whole transitive tree under a matched package is
+      # re-resolved too (an ancestor match propagates the bust downwards).
+      bust_pinned_cache = (is_root || config.update_recursive) && (config.update_all || config.updated_packages.any? do |pattern|
+        name_pattern, _range = Utils::Misc.parse_key(pattern)
+        ::File.match?(name_pattern, name) || (config.update_recursive && ancestors.any? { |a| ::File.match?(name_pattern, a.name) })
       end)
 
       if version_or_alias.is_a?(Data::Package::Alias)
@@ -82,6 +87,81 @@ module Commands::Install::Resolver
         ancestors: Deque(Data::Package).new(ancestors.size + 1).concat(ancestors).push(package),
         bust_pinned_cache: bust_pinned_cache
       )
+    end
+    changed
+  end
+
+  # Applies `zap up pkg@<range>` arguments: the declared specifier of the
+  # matching dependency is replaced with the requested range.
+  private def self.apply_updated_ranges(package : Data::Package, config : Commands::Install::Config) : Bool
+    changed = false
+    config.updated_packages.each do |arg|
+      name, range = Utils::Misc.parse_key(arg)
+      next unless name && range
+      package.dependencies.try &.each_key do |dep_name|
+        next unless ::File.match?(name, dep_name)
+        next if package.dependency_specifier?(dep_name) == range
+        package.dependency_specifier(dep_name, range, Data::Package::DependencyType::Dependency)
+        changed = true
+      end
+      package.dev_dependencies.try &.each_key do |dep_name|
+        next unless ::File.match?(name, dep_name)
+        # Compare against the dev entry itself: dependency_specifier? merges
+        # the hashes, so a dep declared in both would skip the dev update.
+        next if package.dev_dependencies.not_nil![dep_name].to_s == range
+        package.dependency_specifier(dep_name, range, Data::Package::DependencyType::DevDependency)
+        changed = true
+      end
+      package.optional_dependencies.try &.each_key do |dep_name|
+        next unless ::File.match?(name, dep_name)
+        next if package.optional_dependencies.not_nil![dep_name].to_s == range
+        package.dependency_specifier(dep_name, range, Data::Package::DependencyType::OptionalDependency)
+        changed = true
+      end
+    end
+    changed
+  end
+
+  # With --latest, rewrites the declared specifier of updated direct
+  # dependencies to the resolved version, preserving the range modifier
+  # (^, ~, <=, >= or exact). Complex ranges are left untouched.
+  def self.rewrite_latest_specifiers(package : Data::Package, state : Commands::Install::State) : Bool
+    config = state.install_config
+    return false unless config.update_latest
+    return false unless config.update_all || config.updated_packages.size > 0
+    changed = false
+    package.each_dependency_hash(include_dev: true, include_optional: true) do |deps, type|
+      next unless deps
+      deps.each do |name, declared|
+        next unless declared.is_a?(String)
+        # Only touch the packages actually being updated; pins and declared
+        # ranges always differ, so a pin comparison alone is not enough.
+        next unless config.update_all || config.updated_packages.any? do |pattern|
+          name_pattern, _range = Utils::Misc.parse_key(pattern)
+          ::File.match?(name_pattern, name)
+        end
+        resolved = state.lockfile.roots[package.name]?.try(&.dependency_specifier?(name))
+        next unless resolved
+        if modifier = range_modifier(declared)
+          new_specifier = "#{modifier}#{resolved}"
+          next if new_specifier == declared
+          package.dependency_specifier(name, new_specifier, type)
+          changed = true
+        end
+      end
+    end
+    changed
+  end
+
+  private def self.range_modifier(declared : String) : String?
+    if declared.starts_with?("^")
+      "^"
+    elsif declared.starts_with?("~")
+      "~"
+    elsif (match = declared.match(/\A(<=|>=)\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/))
+      match[1]
+    elsif declared.matches?(/\A\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/)
+      ""
     end
   end
 
@@ -157,7 +237,10 @@ module Commands::Install::Resolver
           state.lockfile.packages[metadata_key]?
         end
         lockfile_cached = !!lockfile_metadata
-        _metadata = lockfile_metadata || metadata_ref
+        # In update contexts the lockfile entry is stale (its dependency pins
+        # are resolved versions, not declared ranges), so the freshly resolved
+        # metadata drives the subtree resolution.
+        _metadata = (state.install_config.update_recursive ? metadata_ref : (lockfile_metadata || metadata_ref))
         already_resolved = _metadata.already_resolved?(state)
 
         # Forcefully fetch the metadata from the registry if the force_metadata_retrieval option is enabled
@@ -168,15 +251,16 @@ module Commands::Install::Resolver
         end
 
         # Apply package extensions unless the package is already in the lockfile
-        apply_package_extensions(_metadata, state: state) if forced_retrieval || !lockfile_metadata
+        apply_package_extensions(_metadata, state: state) if forced_retrieval || !lockfile_metadata || state.install_config.update_recursive
         # Flag transitive overrides
         flag_transitive_overrides(_metadata, ancestors, state)
         # Mark the package and store its parents
         # Used to prevent packages being pruned in the lockfile
         _metadata.dependents << package if package
 
-        # Mutate only if the package is not already in the lockfile
-        if !lockfile_metadata || forced_retrieval
+        # Mutate only if the package is not already in the lockfile, or when
+        # an update re-resolved it (so the refreshed dependency pins persist)
+        if !lockfile_metadata || forced_retrieval || state.install_config.update_recursive
           Log.debug { "(#{metadata_key}) Saving package metadata in the lockfile #{(package ? "[parent: #{package.key}]" : "")}" }
           # Remove dev dependencies
           _metadata.dev_dependencies = nil

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -241,7 +241,11 @@ module Commands::Install::Resolver
         # are resolved versions, not declared ranges), so the freshly resolved
         # metadata drives the subtree resolution.
         _metadata = (state.install_config.update_recursive ? metadata_ref : (lockfile_metadata || metadata_ref))
-        already_resolved = _metadata.already_resolved?(state)
+        # The infinite-loop guard is per key, tracked on the state: the fresh
+        # metadata is a new object on every visit (with --recursive), so a
+        # flag on the package itself would never trip, re-resolving the same
+        # subtree forever.
+        already_resolved = !state.resolved_keys.add?(metadata_key)
 
         # Forcefully fetch the metadata from the registry if the force_metadata_retrieval option is enabled
         if (forced_retrieval = lockfile_cached && force_metadata_retrieval && !already_resolved)

--- a/packages/commands/install/state.cr
+++ b/packages/commands/install/state.cr
@@ -19,5 +19,10 @@ module Commands::Install
     npmrc : Data::Npmrc,
     registry_clients : RegistryClients,
     pipeline : Concurrency::Pipeline,
-    reporter : Reporter = Reporter::Interactive.new
+    reporter : Reporter = Reporter::Interactive.new,
+    # Keys of packages whose dependency subtree is currently being resolved
+    # this run; guards the recursive dependency crawl against infinite loops
+    # (a fresh object is used for the metadata on every visit, so the flag
+    # cannot live on the package itself).
+    resolved_keys : Concurrency::SafeSet(String) = Concurrency::SafeSet(String).new
 end

--- a/packages/commands/shard.lock
+++ b/packages/commands/shard.lock
@@ -52,9 +52,9 @@ shards:
     path: ../store
     version: 0.0.1
 
-  term-cursor:
-    git: https://github.com/crystal-term/cursor.git
-    version: 0.1.0+git.commit.8805d5f686d153db92cf2ce3333433f8ed3708d0
+  tui:
+    path: ../tui
+    version: 0.1.3
 
   utils:
     path: ../utils

--- a/packages/commands/shard.yml
+++ b/packages/commands/shard.yml
@@ -16,4 +16,6 @@ dependencies:
     path: ../reporter
   git:
     path: ../git
+  tui:
+    path: ../tui
 crystalline:

--- a/packages/commands/spec/install/integration/engines._spec.cr
+++ b/packages/commands/spec/install/integration/engines._spec.cr
@@ -35,4 +35,25 @@ describe "engines", tags: "integration" do
       end
     end
   end
+  it "tolerates malformed engines metadata (engines published as an array)" do
+    It.with_registry do |registry|
+      # ansi-html-community@0.0.8 publishes `"engines": ["node >= 0.8.0"]`
+      manifest = It.pkg("weird-engines", "1.0.0").merge({"engines" => JSON.parse(%(["node >= 0.8.0"]))})
+      registry.add("weird-engines", "1.0.0", manifest, {"index.js" => "w"})
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"weird-engines":"^1.0.0"}})) do |project|
+        File.read(project / "node_modules/weird-engines/index.js").should eq("w")
+      end
+    end
+  end
+
+  it "tolerates malformed os metadata (os published as a string)" do
+    It.with_registry do |registry|
+      manifest = It.pkg("weird-os", "1.0.0").merge({"os" => JSON.parse(%("linux"))})
+      registry.add("weird-os", "1.0.0", manifest, {"index.js" => "o"})
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"weird-os":"^1.0.0"}})) do |project|
+        File.read(project / "node_modules/weird-os/index.js").should eq("o")
+      end
+    end
+  end
+
 end

--- a/packages/commands/spec/install/integration/interactive._spec.cr
+++ b/packages/commands/spec/install/integration/interactive._spec.cr
@@ -51,7 +51,6 @@ describe "interactive update", tags: "integration" do
         pinned = updateable.find { |u| u.name == "pinned" }.not_nil!
         pinned.current.should eq("1.0.0")
         pinned.target.should eq("1.5.0")
-        pinned.range.should eq("^1.0.0")
       ensure
         FileUtils.rm_rf(tmpdir)
       end
@@ -141,6 +140,37 @@ describe "interactive update", tags: "integration" do
         latest.first.target.should eq("2.0.0")
       ensure
         FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "scans the updateable dependencies of every workspace, deduplicated by name" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws-root","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"ws-a","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/a/index.js", "a")
+        File.write(ws_root / "packages/b/package.json", %({"name":"ws-b","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/b/index.js", "b")
+
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.5.0", It.pkg("pinned", "1.5.0"), {"index.js" => "1.5.0"})
+        updateable = Commands::Install::Interactive.scan(ItState.build(config, ic))
+        # One entry for the dep shared by both workspaces.
+        updateable.map(&.name).should eq(["pinned"])
+        updateable.first.current.should eq("1.0.0")
+        updateable.first.target.should eq("1.5.0")
+      ensure
+        FileUtils.rm_rf(ws_root)
       end
     end
   end

--- a/packages/commands/spec/install/integration/interactive._spec.cr
+++ b/packages/commands/spec/install/integration/interactive._spec.cr
@@ -175,4 +175,26 @@ describe "interactive update", tags: "integration" do
     end
   end
 
+  it "fails fast when the lockfile is missing" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        # No install ran: there is no lockfile to read current versions from.
+        state = ItState.build(config, ic)
+        expect_raises(Exception, /lockfile/) do
+          Commands::Install::Interactive.scan(state)
+        end
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
 end

--- a/packages/commands/spec/install/integration/interactive._spec.cr
+++ b/packages/commands/spec/install/integration/interactive._spec.cr
@@ -1,0 +1,148 @@
+require "./spec_helper"
+
+module ItState
+  # Mirrors the State construction in Install.run so the scan can be exercised
+  # against a real registry without a TTY.
+  def self.build(config : Core::Config, ic : Commands::Install::Config) : Commands::Install::State
+    inferred = config.infer_context
+    lockfile = Data::Lockfile.new(inferred.config.prefix)
+    npmrc = Data::Npmrc.new(inferred.config.prefix)
+    Commands::Install::State.new(
+      config: inferred.config,
+      install_config: ic,
+      store: ::Store.new(inferred.config.store_path),
+      main_package: inferred.main_package,
+      lockfile: lockfile,
+      context: inferred,
+      npmrc: npmrc,
+      registry_clients: Commands::Install::RegistryClients.new(inferred.config.store_path, npmrc, pool_max_size: 4),
+      pipeline: Concurrency::Pipeline.new(workers: 1),
+      reporter: Reporter::Null.new
+    )
+  end
+end
+
+# The interactive update scans the direct dependencies and reports the ones
+# with a newer version available within their declared range.
+describe "interactive update", tags: "integration" do
+  it "scans the updateable direct dependencies" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("fresh", "1.0.0", It.pkg("fresh", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("stale", "1.0.0", It.pkg("stale", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0","fresh":"^1.0.0","stale":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # pinned: newer in-range version; fresh: newer but out of range;
+        # stale: nothing newer.
+        registry.add("pinned", "1.5.0", It.pkg("pinned", "1.5.0"), {"index.js" => "1.5.0"})
+        registry.add("fresh", "2.0.0", It.pkg("fresh", "2.0.0"), {"index.js" => "2.0.0"})
+
+        state = ItState.build(config, ic)
+        updateable = Commands::Install::Interactive.scan(state)
+        updateable.map(&.name).should eq(["pinned"])
+        pinned = updateable.find { |u| u.name == "pinned" }.not_nil!
+        pinned.current.should eq("1.0.0")
+        pinned.target.should eq("1.5.0")
+        pinned.range.should eq("^1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "scans dev and optional dependencies too" do
+    It.with_registry do |registry|
+      registry.add("devpkg", "1.0.0", It.pkg("devpkg", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("optpkg", "1.0.0", It.pkg("optpkg", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","devDependencies":{"devpkg":"^1.0.0"},"optionalDependencies":{"optpkg":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("devpkg", "1.2.0", It.pkg("devpkg", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("optpkg", "1.2.0", It.pkg("optpkg", "1.2.0"), {"index.js" => "1.2.0"})
+
+        state = ItState.build(config, ic)
+        updateable = Commands::Install::Interactive.scan(state)
+        updateable.map(&.name).sort.should eq(["devpkg", "optpkg"])
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+  it "only lists registry ranges, skipping aliases and git specifiers" do
+    It.with_registry do |registry|
+      registry.add("plain", "1.0.0", It.pkg("plain", "1.0.0"), {"index.js" => "1.0.0"})
+
+      repo = Path.new(Dir.tempdir, "zap-git-#{Random::Secure.hex(4)}")
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        It.make_git_repo(repo, %({"name":"gitted","version":"1.0.0","main":"index.js"}), {"index.js" => "v1"})
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"plain":"^1.0.0","my-alias":"npm:plain@1.0.0","gitted":"git+file://#{repo}#main"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("plain", "1.5.0", It.pkg("plain", "1.5.0"), {"index.js" => "1.5.0"})
+
+        state = ItState.build(config, ic)
+        updateable = Commands::Install::Interactive.scan(state)
+        updateable.map(&.name).should eq(["plain"])
+      ensure
+        FileUtils.rm_rf(repo)
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "colors the version arrow by bump severity" do
+    Commands::Install::Interactive.bump_color("1.0.0", "2.0.0").should eq(Tui::Ansi::RED)
+    Commands::Install::Interactive.bump_color("1.0.0", "1.1.0").should eq(Tui::Ansi::YELLOW)
+    Commands::Install::Interactive.bump_color("1.0.0", "1.0.1").should eq(Tui::Ansi::GREEN)
+  end
+
+  it "computes latest targets with --latest, matching the apply" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.5.0", It.pkg("pinned", "1.5.0"), {"index.js" => "1.5.0"})
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+
+        # Without --latest the target is in-range.
+        in_range = Commands::Install::Interactive.scan(ItState.build(config, ic))
+        in_range.first.target.should eq("1.5.0")
+
+        # With --latest the target is the newest overall (out of range).
+        latest = Commands::Install::Interactive.scan(ItState.build(config, ic.copy_with(update_latest: true)))
+        latest.first.target.should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+end

--- a/packages/commands/spec/install/integration/peers._spec.cr
+++ b/packages/commands/spec/install/integration/peers._spec.cr
@@ -90,4 +90,158 @@ describe "peer dependencies", tags: "integration" do
       end
     end
   end
+
+  it "marks transitive peers per providing ancestor in a diamond" do
+    It.with_registry do |registry|
+      registry.add("react", "1.0.0", It.pkg("react", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("widget", "1.0.0", It.pkg("widget", "1.0.0", peer_dependencies: {"react" => "*"}), {"index.js" => "w"})
+      registry.add("parent-a", "1.0.0", It.pkg("parent-a", "1.0.0", dependencies: {"react" => "1.0.0", "widget" => "1.0.0"}), {"index.js" => "a"})
+      registry.add("parent-b", "1.0.0", It.pkg("parent-b", "1.0.0", dependencies: {"widget" => "1.0.0"}), {"index.js" => "b"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent-a":"1.0.0","parent-b":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # Rebuild the state and re-resolve in-process: the dependency refs
+        # the reduce walks are not persisted in the lockfile.
+        inferred = config.infer_context
+        state = Commands::Install::State.new(
+          config: inferred.config,
+          install_config: ic,
+          store: ::Store.new(inferred.config.store_path),
+          main_package: inferred.main_package,
+          lockfile: Data::Lockfile.new(inferred.config.prefix),
+          context: inferred,
+          npmrc: Data::Npmrc.new(inferred.config.prefix),
+          registry_clients: Commands::Install::RegistryClients.new(inferred.config.store_path, Data::Npmrc.new(inferred.config.prefix), pool_max_size: 4),
+          pipeline: Concurrency::Pipeline.new(workers: 1),
+          reporter: Reporter::Null.new
+        )
+        state.context.scope_packages(:install).each do |pkg|
+          Commands::Install::Resolver.resolve_dependencies_of(pkg, state: state)
+        end
+        state.pipeline.await
+
+        state.lockfile.mark_transitive_peers
+        a = state.lockfile.get_package("parent-a", "1.0.0")
+        b = state.lockfile.get_package("parent-b", "1.0.0")
+
+        # parent-a depends on react: the propagated peer is resolved there.
+        a.transitive_peer_dependencies.should be_nil
+        # parent-b does not: the peer is unresolved below it.
+        b.transitive_peer_dependencies.not_nil!["react"].should_not be_empty
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "propagates peers through cyclic dependencies (fixpoint union)" do
+    It.with_registry do |registry|
+      registry.add("engine", "1.0.0", It.pkg("engine", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("widget", "1.0.0", It.pkg("widget", "1.0.0", dependencies: {"helper" => "1.0.0"}), {"index.js" => "w"})
+      registry.add("helper", "1.0.0", It.pkg("helper", "1.0.0", dependencies: {"widget" => "1.0.0"}, peer_dependencies: {"engine" => "*"}), {"index.js" => "h"})
+      registry.add("left", "1.0.0", It.pkg("left", "1.0.0", dependencies: {"widget" => "1.0.0"}), {"index.js" => "l"})
+      registry.add("right", "1.0.0", It.pkg("right", "1.0.0", dependencies: {"helper" => "1.0.0"}), {"index.js" => "r"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"left":"1.0.0","right":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        inferred = config.infer_context
+        state = Commands::Install::State.new(
+          config: inferred.config,
+          install_config: ic,
+          store: ::Store.new(inferred.config.store_path),
+          main_package: inferred.main_package,
+          lockfile: Data::Lockfile.new(inferred.config.prefix),
+          context: inferred,
+          npmrc: Data::Npmrc.new(inferred.config.prefix),
+          registry_clients: Commands::Install::RegistryClients.new(inferred.config.store_path, Data::Npmrc.new(inferred.config.prefix), pool_max_size: 4),
+          pipeline: Concurrency::Pipeline.new(workers: 1),
+          reporter: Reporter::Null.new
+        )
+        state.context.scope_packages(:install).each do |pkg|
+          Commands::Install::Resolver.resolve_dependencies_of(pkg, state: state)
+        end
+        state.pipeline.await
+
+        state.lockfile.mark_transitive_peers
+        widget = state.lockfile.get_package("widget", "1.0.0")
+        left = state.lockfile.get_package("left", "1.0.0")
+        right = state.lockfile.get_package("right", "1.0.0")
+
+        # helper's peer escapes the cycle through both entries: the union
+        # semantics mark widget, left and right regardless of traversal order.
+        widget.transitive_peer_dependencies.not_nil!["engine"].should_not be_empty
+        left.transitive_peer_dependencies.not_nil!["engine"].should_not be_empty
+        right.transitive_peer_dependencies.not_nil!["engine"].should_not be_empty
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "propagates peers across workspace dependency edges" do
+    It.with_registry do |registry|
+      registry.add("engine", "1.0.0", It.pkg("engine", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir / "packages/a")
+        Dir.mkdir_p(tmpdir / "packages/b")
+        Dir.mkdir_p(tmpdir / "packages/c")
+        File.write(tmpdir / "package.json", %({"name":"root","version":"1.0.0","workspaces":["packages/*"],"dependencies":{"@ws/c":"workspace:^"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(tmpdir / "packages/a/package.json", %({"name":"@ws/a","version":"1.0.0","peerDependencies":{"engine":"*"},"main":"index.js"}))
+        File.write(tmpdir / "packages/a/index.js", "a")
+        File.write(tmpdir / "packages/b/package.json", %({"name":"@ws/b","version":"1.0.0","dependencies":{"@ws/a":"workspace:^"},"main":"index.js"}))
+        File.write(tmpdir / "packages/b/index.js", "b")
+        File.write(tmpdir / "packages/c/package.json", %({"name":"@ws/c","version":"1.0.0","dependencies":{"@ws/b":"workspace:^"},"main":"index.js"}))
+        File.write(tmpdir / "packages/c/index.js", "c")
+
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        inferred = config.infer_context
+        state = Commands::Install::State.new(
+          config: inferred.config,
+          install_config: ic,
+          store: ::Store.new(inferred.config.store_path),
+          main_package: inferred.main_package,
+          lockfile: Data::Lockfile.new(inferred.config.prefix),
+          context: inferred,
+          npmrc: Data::Npmrc.new(inferred.config.prefix),
+          registry_clients: Commands::Install::RegistryClients.new(inferred.config.store_path, Data::Npmrc.new(inferred.config.prefix), pool_max_size: 4),
+          pipeline: Concurrency::Pipeline.new(workers: 1),
+          reporter: Reporter::Null.new
+        )
+        state.context.scope_packages(:install).each do |pkg|
+          Commands::Install::Resolver.resolve_dependencies_of(pkg, state: state)
+        end
+        state.pipeline.await
+
+        state.lockfile.mark_transitive_peers
+        # @ws/b (a stored transitive workspace) depends on @ws/a through a
+        # workspace: pin; @ws/a's peer must reach it via the reverse edge.
+        b_key = state.lockfile.packages.keys.find { |k| k.starts_with?("@ws/b@") }
+        b_key.should_not be_nil
+        b = state.lockfile.packages[b_key.not_nil!]
+        b.transitive_peer_dependencies.not_nil!["engine"].should_not be_empty
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
 end

--- a/packages/commands/spec/install/integration/update._spec.cr
+++ b/packages/commands/spec/install/integration/update._spec.cr
@@ -63,4 +63,660 @@ describe "update semantics", tags: "integration" do
       end
     end
   end
+  it "bumps outside the range with --latest and preserves the modifier" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The range is rewritten with the same modifier
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("^2.0.0")
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "keeps an exact version exact with --latest" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "leaves complex ranges untouched with --latest" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("pinned", "1.5.0", It.pkg("pinned", "1.5.0"), {"index.js" => "1.5.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":">=1.0.0 <2.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "3.0.0", It.pkg("pinned", "3.0.0"), {"index.js" => "3.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The complex range cannot be rewritten, so it stays in-range
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq(">=1.0.0 <2.0.0")
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("1.5.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "updates transitive dependencies with --recursive" do
+    It.with_registry do |registry|
+      registry.add("child", "1.0.0", It.pkg("child", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "parent"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "node_modules/child/index.js").should eq("1.0.0")
+
+        registry.add("child", "1.5.0", It.pkg("child", "1.5.0"), {"index.js" => "1.5.0"})
+        recursive = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_recursive: true)
+        Commands::Install.run(config, recursive, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "node_modules/child/index.js").should eq("1.5.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "does not update transitive dependencies without --recursive" do
+    It.with_registry do |registry|
+      registry.add("child", "1.0.0", It.pkg("child", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "parent"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("child", "1.5.0", It.pkg("child", "1.5.0"), {"index.js" => "1.5.0"})
+        plain = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true)
+        Commands::Install.run(config, plain, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "node_modules/child/index.js").should eq("1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "sets a new range with zap up pkg@range" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        targeted = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["pinned@^2.0.0"])
+        Commands::Install.run(config, targeted, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("^2.0.0")
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "does not pick prereleases when updating" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.5.0", It.pkg("pinned", "1.5.0"), {"index.js" => "1.5.0"})
+        registry.add("pinned", "2.0.0-beta.1", It.pkg("pinned", "2.0.0-beta.1"), {"index.js" => "beta"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The prerelease is not picked even with --latest
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("1.5.0")
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("^1.5.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "leaves the manifest byte-identical when an update changes nothing" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        manifest = %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}})
+        File.write(tmpdir / "package.json", manifest)
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        plain = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true)
+        Commands::Install.run(config, plain, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "package.json").should eq(manifest)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "rewrites only the named package with zap up pkg --latest" do
+    It.with_registry do |registry|
+      registry.add("stay", "1.0.0", It.pkg("stay", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("bump", "1.0.0", It.pkg("bump", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"stay":"^1.0.0","bump":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("bump", "2.0.0", It.pkg("bump", "2.0.0"), {"index.js" => "2.0.0"})
+        targeted = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["bump"], update_latest: true)
+        Commands::Install.run(config, targeted, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["bump"].as_s.should eq("^2.0.0")
+        # The unrelated dependency is untouched
+        pkg["dependencies"]["stay"].as_s.should eq("^1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "updates the subtree of a named package with zap up pkg --recursive" do
+    It.with_registry do |registry|
+      registry.add("child", "1.0.0", It.pkg("child", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "parent"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("child", "1.5.0", It.pkg("child", "1.5.0"), {"index.js" => "1.5.0"})
+        targeted = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["parent"], update_recursive: true)
+        Commands::Install.run(config, targeted, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "node_modules/child/index.js").should eq("1.5.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "preserves the <= range with --latest (yarn upgrade port)" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"<=1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("<=2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "preserves the >= range with --latest" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":">=1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq(">=2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "does not downgrade a prerelease with --latest (yarn upgrade port)" do
+    It.with_registry do |registry|
+      registry.add("react-refetch", "1.0.3-0", It.pkg("react-refetch", "1.0.3-0"), {"index.js" => "beta"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react-refetch":"^1.0.3-0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.read(tmpdir / "node_modules/react-refetch/index.js").should eq("beta")
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["react-refetch"].as_s.should eq("^1.0.3-0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "rewrites devDependencies with --latest" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","devDependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["devDependencies"]["pinned"].as_s.should eq("^2.0.0")
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "leaves the manifest byte-identical when --latest finds nothing new" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        manifest = %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}})
+        File.write(tmpdir / "package.json", manifest)
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "package.json").should eq(manifest)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "leaves the manifest byte-identical when re-running zap up pkg@range" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        manifest = %({"name":"app","version":"1.0.0","dependencies":{"pinned":"1.0.0"}})
+        File.write(tmpdir / "package.json", manifest)
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The range is already 1.0.0; re-running must not touch the manifest
+        targeted = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["pinned@1.0.0"])
+        Commands::Install.run(config, targeted, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "package.json").should eq(manifest)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "preserves the ~ range with --latest" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"~1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.9.0", It.pkg("pinned", "1.9.0"), {"index.js" => "1.9.0"})
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("~2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "keeps npm aliases intact when an update rewrites the manifest" do
+    It.with_registry do |registry|
+      registry.add("real-pkg", "1.0.0", It.pkg("real-pkg", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("bump", "1.0.0", It.pkg("bump", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"my-alias":"npm:real-pkg@1.0.0","bump":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("bump", "2.0.0", It.pkg("bump", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["bump"].as_s.should eq("^2.0.0")
+        pkg["dependencies"]["my-alias"].as_s.should eq("npm:real-pkg@1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "rewrites every workspace manifest with --latest, not only the command scope" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws-root","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"ws-a","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/a/index.js", "a")
+        File.write(ws_root / "packages/b/package.json", %({"name":"ws-b","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/b/index.js", "b")
+
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        JSON.parse(File.read(ws_root / "packages/a/package.json"))["dependencies"]["pinned"].as_s.should eq("^2.0.0")
+        JSON.parse(File.read(ws_root / "packages/b/package.json"))["dependencies"]["pinned"].as_s.should eq("^2.0.0")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "re-resolves every workspace for pkg@range updates, not only the command scope" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws-root","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"ws-a","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/a/index.js", "a")
+        File.write(ws_root / "packages/b/package.json", %({"name":"ws-b","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}}))
+        File.write(ws_root / "packages/b/index.js", "b")
+
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.2.0", It.pkg("pinned", "1.2.0"), {"index.js" => "1.2.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["pinned@^1.2.0"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        JSON.parse(File.read(ws_root / "packages/a/package.json"))["dependencies"]["pinned"].as_s.should eq("^1.2.0")
+        JSON.parse(File.read(ws_root / "packages/b/package.json"))["dependencies"]["pinned"].as_s.should eq("^1.2.0")
+        lockfile = Data::Lockfile.new(ws_root)
+        lockfile.roots["ws-a"].dependency_specifier?("pinned").should eq("1.2.0")
+        lockfile.roots["ws-b"].dependency_specifier?("pinned").should eq("1.2.0")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "updates a dep declared in both dependencies and devDependencies with pkg@range" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"},"devDependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.2.0", It.pkg("pinned", "1.2.0"), {"index.js" => "1.2.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["pinned@^1.2.0"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["pinned"].as_s.should eq("^1.2.0")
+        pkg["devDependencies"]["pinned"].as_s.should eq("^1.2.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "updates an optionalDependencies entry with pkg@range" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","optionalDependencies":{"pinned":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("pinned", "1.2.0", It.pkg("pinned", "1.2.0"), {"index.js" => "1.2.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["pinned@^1.2.0"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["optionalDependencies"]["pinned"].as_s.should eq("^1.2.0")
+        File.read(tmpdir / "node_modules/pinned/index.js").should eq("1.2.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "keeps transitive dependencies within their declared range with --latest --recursive" do
+    It.with_registry do |registry|
+      registry.add("child", "1.0.0", It.pkg("child", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "parent"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("child", "1.5.0", It.pkg("child", "1.5.0"), {"index.js" => "1.5.0"})
+        registry.add("child", "2.0.0", It.pkg("child", "2.0.0"), {"index.js" => "2.0.0"})
+        combo = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true, update_recursive: true)
+        Commands::Install.run(config, combo, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # --latest only bumps direct dependencies; the transitive re-resolution
+        # stays within the declared range, never outside it
+        File.read(tmpdir / "node_modules/child/index.js").should eq("1.5.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "applies --latest to overridden direct dependencies without crashing" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "2.0.0", It.pkg("dep", "2.0.0"), {"index.js" => "2.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"dep":"^1.0.0"},"overrides":{"dep":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        latest = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, latest, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The override resolves in lockstep with the direct dependency
+        File.read(tmpdir / "node_modules/dep/index.js").should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "keeps the overridden version when pkg@range changes the declared range" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "2.0.0", It.pkg("dep", "2.0.0"), {"index.js" => "2.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"dep":"^1.0.0"},"overrides":{"dep":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["dep@^2.0.0"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The manifest range updates but the override keeps its version (npm
+        # parity: the override wins), and the update must not crash.
+        JSON.parse(File.read(tmpdir / "package.json"))["dependencies"]["dep"].as_s.should eq("^2.0.0")
+        File.read(tmpdir / "node_modules/dep/index.js").should eq("1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
 end

--- a/packages/commands/spec/install/integration/update._spec.cr
+++ b/packages/commands/spec/install/integration/update._spec.cr
@@ -747,4 +747,229 @@ describe "update semantics", tags: "integration" do
     end
   end
 
+  # Ports from yarn berry (up.test.ts) and pnpm (installing/commands/test/update).
+  it "upgrades all dependencies matching a glob pattern (yarn berry port)" do
+    It.with_registry do |registry|
+      registry.add("@scope/alpha", "1.0.0", It.pkg("@scope/alpha", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("@scope/beta", "1.0.0", It.pkg("@scope/beta", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("plain", "1.0.0", It.pkg("plain", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"@scope/alpha":"^1.0.0","@scope/beta":"^1.0.0","plain":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("@scope/alpha", "2.0.0", It.pkg("@scope/alpha", "2.0.0"), {"index.js" => "2.0.0"})
+        registry.add("@scope/beta", "2.0.0", It.pkg("@scope/beta", "2.0.0"), {"index.js" => "2.0.0"})
+        registry.add("plain", "2.0.0", It.pkg("plain", "2.0.0"), {"index.js" => "2.0.0"})
+
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_latest: true, updated_packages: ["@scope/*"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["@scope/alpha"].as_s.should eq("^2.0.0")
+        pkg["dependencies"]["@scope/beta"].as_s.should eq("^2.0.0")
+        pkg["dependencies"]["plain"].as_s.should eq("^1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "upgrades all dependencies matching a glob pattern with a range (yarn berry port)" do
+    It.with_registry do |registry|
+      registry.add("@scope/alpha", "1.0.0", It.pkg("@scope/alpha", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("@scope/alpha", "2.0.0", It.pkg("@scope/alpha", "2.0.0"), {"index.js" => "2.0.0"})
+      registry.add("@scope/beta", "1.0.0", It.pkg("@scope/beta", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("@scope/beta", "2.0.0", It.pkg("@scope/beta", "2.0.0"), {"index.js" => "2.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"@scope/alpha":"^2.0.0","@scope/beta":"^2.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["@scope/*@1.0.0"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["@scope/alpha"].as_s.should eq("1.0.0")
+        pkg["dependencies"]["@scope/beta"].as_s.should eq("1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "updates everything except a negated glob pattern (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("peer-a", "1.0.0", It.pkg("peer-a", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("foo", "1.0.0", It.pkg("foo", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"peer-a":"1.0.0","foo":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("peer-a", "2.0.0", It.pkg("peer-a", "2.0.0"), {"index.js" => "2.0.0"})
+        registry.add("foo", "2.0.0", It.pkg("foo", "2.0.0"), {"index.js" => "2.0.0"})
+
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_latest: true, updated_packages: ["!peer-a"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["peer-a"].as_s.should eq("1.0.0")
+        # the exact specifier stays exact (zap preserves the modifier)
+        pkg["dependencies"]["foo"].as_s.should eq("2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "mixes positive and negated patterns: only the positives update (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("peer-a", "1.0.0", It.pkg("peer-a", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("other", "1.0.0", It.pkg("other", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("foo", "1.0.0", It.pkg("foo", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"peer-a":"1.0.0","other":"1.0.0","foo":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("peer-a", "2.0.0", It.pkg("peer-a", "2.0.0"), {"index.js" => "2.0.0"})
+        registry.add("other", "2.0.0", It.pkg("other", "2.0.0"), {"index.js" => "2.0.0"})
+        registry.add("foo", "2.0.0", It.pkg("foo", "2.0.0"), {"index.js" => "2.0.0"})
+
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_latest: true, updated_packages: ["foo", "!peer-a"])
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["foo"].as_s.should eq("2.0.0")
+        pkg["dependencies"]["peer-a"].as_s.should eq("1.0.0")
+        pkg["dependencies"]["other"].as_s.should eq("1.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "does not touch the manifest or lockfile with save disabled (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("pinned", "1.0.0", It.pkg("pinned", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        manifest = %({"name":"app","version":"1.0.0","dependencies":{"pinned":"^1.0.0"}})
+        File.write(tmpdir / "package.json", manifest)
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile_before = File.read(tmpdir / "zap.lock")
+
+        registry.add("pinned", "2.0.0", It.pkg("pinned", "2.0.0"), {"index.js" => "2.0.0"})
+        no_save = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: false, update_all: true, update_latest: true)
+        Commands::Install.run(config, no_save, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.read(tmpdir / "package.json").should eq(manifest)
+        File.read(tmpdir / "zap.lock").should eq(lockfile_before)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "resolves an npm: alias to the latest of the aliased package with --latest (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("real", "1.0.0", It.pkg("real", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"foo-alias":"npm:real@~1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("real", "100.1.0", It.pkg("real", "100.1.0"), {"index.js" => "100.1.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["foo-alias"].as_s.should eq("npm:real@~100.1.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "does not update dist-tag specifiers without --latest (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("tagged", "1.0.0", It.pkg("tagged", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        manifest = %({"name":"app","version":"1.0.0","dependencies":{"tagged":"latest"}})
+        File.write(tmpdir / "package.json", manifest)
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("tagged", "2.0.0", It.pkg("tagged", "2.0.0"), {"index.js" => "2.0.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true)
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.read(tmpdir / "package.json").should eq(manifest)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "updates dependencies with an empty declared specifier (pnpm port)" do
+    It.with_registry do |registry|
+      registry.add("foo", "1.0.0", It.pkg("foo", "1.0.0"), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","devDependencies":{"foo":""}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("foo", "2.0.0", It.pkg("foo", "2.0.0"), {"index.js" => "2.0.0"})
+        up = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true)
+        Commands::Install.run(config, up, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(tmpdir)
+        lockfile.packages.keys.should contain("foo@2.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
 end

--- a/packages/commands/spec/install/integration/update._spec.cr
+++ b/packages/commands/spec/install/integration/update._spec.cr
@@ -719,4 +719,32 @@ describe "update semantics", tags: "integration" do
     end
   end
 
+  it "does not loop forever on a diamond dependency graph with --recursive" do
+    It.with_registry do |registry|
+      registry.add("d", "1.0.0", It.pkg("d", "1.0.0"), {"index.js" => "d"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"d" => "^1.0.0"}), {"index.js" => "b"})
+      registry.add("c", "1.0.0", It.pkg("c", "1.0.0", dependencies: {"d" => "^1.0.0"}), {"index.js" => "c"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"b" => "^1.0.0", "c" => "^1.0.0"}), {"index.js" => "a"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("d", "1.5.0", It.pkg("d", "1.5.0"), {"index.js" => "d2"})
+        recursive = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_recursive: true)
+        Commands::Install.run(config, recursive, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The recursion guard must trip on the shared transitive, not loop
+        File.read(tmpdir / "node_modules/d/index.js").should eq("d2")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
 end

--- a/packages/commands/spec/install/integration/update._spec.cr
+++ b/packages/commands/spec/install/integration/update._spec.cr
@@ -972,4 +972,39 @@ describe "update semantics", tags: "integration" do
     end
   end
 
+  it "keeps resolved pins on a shared transitive during --recursive --latest" do
+    It.with_registry do |registry|
+      registry.add("grandchild", "1.0.0", It.pkg("grandchild", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("child", "1.0.0", It.pkg("child", "1.0.0", dependencies: {"grandchild" => "^1.0.0"}), {"index.js" => "1.0.0"})
+      registry.add("parent-a", "1.0.0", It.pkg("parent-a", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "1.0.0"})
+      registry.add("parent-b", "1.0.0", It.pkg("parent-b", "1.0.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "1.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"parent-a":"^1.0.0","parent-b":"^1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        registry.add("grandchild", "1.1.0", It.pkg("grandchild", "1.1.0"), {"index.js" => "1.1.0"})
+        registry.add("child", "1.1.0", It.pkg("child", "1.1.0", dependencies: {"grandchild" => "^1.0.0"}), {"index.js" => "1.1.0"})
+        registry.add("parent-a", "1.1.0", It.pkg("parent-a", "1.1.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "1.1.0"})
+        registry.add("parent-b", "1.1.0", It.pkg("parent-b", "1.1.0", dependencies: {"child" => "^1.0.0"}), {"index.js" => "1.1.0"})
+
+        update_ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_latest: true, update_recursive: true, strategy: Data::Package::InstallStrategy::Isolated)
+        Commands::Install.run(config, update_ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # child is reached from both parents; the second visit must not
+        # overwrite the entry with the declared ranges, or the linker would
+        # fail looking up grandchild@^1.0.0.
+        lockfile = Data::Lockfile.new(tmpdir)
+        child = lockfile.packages["child@1.1.0"]
+        child.dependencies.not_nil!["grandchild"].should eq("1.1.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
 end

--- a/packages/data/lockfile.cr
+++ b/packages/data/lockfile.cr
@@ -256,44 +256,92 @@ class Data::Lockfile
     diff
   end
 
-  def mark_transitive_peers(*, roots = self.roots) : Array(Tuple(Data::Lockfile::Root, Array(Tuple(String, Semver::Range, Data::Package))))
-    unmet_peers_by_roots = reduce_roots(Tuple(String, Semver::Range, Package), roots: roots) do |package, type, root, ancestors, unresolved_peers|
-      # For each package, filter unresolved (transitive) peers after all its dependencies have been crawled.
-      # "Transitive peers" are inherited from children (it is the sum of all unresolved peers)
-      transitive_peers = unresolved_peers.reject do |(peer_name, peer_range)|
-        # The peer is resolved if the current package is the peer itself
-        if package.name == peer_name && peer_range.satisfies?(package.version)
-          next true
-        end
+  # A peer need propagating upward: the peer's name, the demanded range and
+  # the package that declared it (kept for reporting).
+  alias PeerNeed = Tuple(String, Semver::Range, Data::Package)
 
-        # The peer is resolved if the current package has the peer as a direct dependency
-        if specifier = package.dependency_specifier?(peer_name)
-          if peer_range.satisfies?(specifier.is_a?(Package::Alias) ? specifier.version : specifier)
-            next true
-          end
+  def mark_transitive_peers(*, roots = self.roots) : Array(Tuple(Data::Lockfile::Root, Array(PeerNeed)))
+    # Each package's need-set only grows as peers propagate upward, so a
+    # monotone worklist fixpoint computes the union over all paths exactly:
+    # no per-path re-walk of shared cores, and cycles converge instead of
+    # looping (the ancestor-pruned recursion they replace could not be
+    # memoized exactly, since the pruning differs per path).
+    needs = Hash(String, Set(PeerNeed)).new
+    own = Hash(String, Set(PeerNeed)).new
+    packages.each_value do |pkg|
+      next unless peer_deps = pkg.peer_dependencies
+      set = Set(PeerNeed).new
+      peer_deps.each do |peer_name, peer_range|
+        set << {peer_name, Semver.parse?(peer_range).or(Semver::ANY), pkg}
+      end
+      own[pkg.key] = set
+      needs[pkg.key] = set
+    end
+
+    # Reverse edges: every package that depends on each package. The child
+    # key must match the lockfile entry key: workspace: pins are stored as
+    # the declared specifier ("workspace:^") while the entry is keyed by the
+    # resolved one ("name@workspace:name"), so both map to the same target.
+    parents = Hash(String, Array(Data::Package)).new
+    packages.each_value do |pkg|
+      pkg.each_dependency do |name, version_or_alias, _type|
+        child_key = if version_or_alias.is_a?(Data::Package::Alias)
+                      version_or_alias.key
+                    elsif version_or_alias.starts_with?("workspace:")
+                      "#{name}@workspace:#{name}"
+                    else
+                      "#{name}@#{version_or_alias}"
+                    end
+        (parents[child_key] ||= [] of Data::Package) << pkg
+      end
+    end
+
+    worklist = Deque(String).new(needs.keys)
+    while (key = worklist.shift?)
+      need_set = needs[key]?
+      next unless need_set
+      parents[key]?.try &.each do |parent|
+        incoming = need_set.select { |(peer_name, peer_range, _)| !peer_resolved_by?(parent, peer_name, peer_range) }.to_set
+        next if incoming.empty?
+        parent_needs = (needs[parent.key] ||= Set(PeerNeed).new)
+        new_needs = incoming - parent_needs
+        next if new_needs.empty?
+        parent_needs.concat(new_needs)
+        worklist << parent.key
+      end
+    end
+
+    # The transitive marks are the inherited needs only: a package's own peer
+    # declarations are already tracked in peer_dependencies.
+    needs.each do |key, need_set|
+      pkg = packages[key]
+      inherited = need_set - (own[key]? || Set(PeerNeed).new)
+      next if inherited.empty?
+      transitive = (pkg.transitive_peer_dependencies ||= Hash(String, Set(Semver::Range)).new)
+      inherited.each do |(peer_name, peer_range, _)|
+        (transitive[peer_name] ||= Set(Semver::Range).new) << peer_range
+      end
+    end
+
+    roots.map do |root_name, root|
+      results = [] of PeerNeed
+      root.each_dependency do |name, version, type|
+        if package = get_package?(name, version)
+          results.concat(needs[package.key]? || [] of PeerNeed)
         end
       end
+      {root, results}
+    end
+  end
 
-      if transitive_peers.size > 0
-        # if this path to the package has transitive peers, append them to the transitive peer list
-        pkg_transitive_peers = (package.transitive_peer_dependencies ||= Hash(String, Set(Semver::Range)).new)
-        transitive_peers.each do |(peer_name, peer_range)|
-          (pkg_transitive_peers[peer_name] ||= Set(Semver::Range).new) << peer_range
-        end
-      end
-
-      if pkg_peers = package.peer_dependencies
-        # pkg_peers = pkg_peers.reject do |peer|
-        #   package.has_dependency?(peer)
-        # end
-        # Return the unresolved transitive peers + its own peers to the ancestor package
-        transitive_peers + pkg_peers.map do |peer_name, peer_range|
-          {peer_name, Semver.parse?(peer_range).or(Semver::ANY), package}
-        end
-      else
-        # No own peer dependencies, return only the unresolved peers
-        transitive_peers
-      end
+  # Whether *package* resolves a peer need itself: it is the peer at a
+  # satisfying version, or it depends on the peer at a satisfying version.
+  private def peer_resolved_by?(package : Data::Package, peer_name : String, peer_range : Semver::Range) : Bool
+    return true if package.name == peer_name && peer_range.satisfies?(package.version)
+    if specifier = package.dependency_specifier?(peer_name)
+      peer_range.satisfies?(specifier.is_a?(Data::Package::Alias) ? specifier.version : specifier)
+    else
+      false
     end
   end
 
@@ -329,43 +377,6 @@ class Data::Lockfile
     ancestors.pop
 
     yield package, type, root, ancestors
-  end
-
-  def reduce_roots(
-    _type : T.class,
-    *,
-    roots = self.roots,
-    &block : Data::Package, DependencyType, Root, Deque({Data::Package, DependencyType}), Array(T) -> Array(T)
-  ) forall T
-    roots.map do |root_name, root|
-      results = [] of T
-      root.each_dependency do |name, version, type|
-        if package = get_package?(name, version)
-          results.concat(reduce_package(_type, package, type, root, &block))
-        end
-      end
-      {root, results}
-    end
-  end
-
-  private def reduce_package(
-    _type : T.class,
-    package : Data::Package,
-    type : DependencyType,
-    root : Root,
-    ancestors : Deque({Package, DependencyType}) = Deque({Package, DependencyType}).new,
-    &block : Data::Package, DependencyType, Root, Deque({Package, DependencyType}), Array(T) -> Array(T)
-  ) : Array(T) forall T
-    results = [] of T
-    return results if ancestors.any? { |(ancestor, ancestor_type)| ancestor == package }
-
-    ancestors << {package, type}
-    package.each_dependency_ref do |dependency, type|
-      results.concat(reduce_package(_type, dependency, type, root, ancestors, &block))
-    end
-    ancestors.pop
-
-    yield package, type, root, ancestors, results
   end
 
   class Root

--- a/packages/data/lockfile.cr
+++ b/packages/data/lockfile.cr
@@ -150,7 +150,7 @@ class Data::Lockfile
       Log.debug { "(#{pkg.key}) All roots: #{root_dependents}" }
 
       # Do not prune packages that were marked during the resolution phase
-      (!is_in_scope || !root_dependents.empty?).tap do |kept|
+      (!is_in_scope || !root_dependents.empty? || pkg.prevent_pruning).tap do |kept|
         Log.debug { "(#{pkg.key}) Pruned from lockfile" } unless kept
       end
     end

--- a/packages/data/package/fields/core.cr
+++ b/packages/data/package/fields/core.cr
@@ -6,6 +6,41 @@ require "../alias"
 require "../lifecycle_scripts"
 require "../overrides"
 
+# Tolerant parsers for package.json fields that npm's registry sometimes
+# publishes malformed (e.g. `engines` as an array instead of an object).
+# Malformed values are ignored, like npm does, instead of failing the install.
+module Data::Package::TolerantHash
+
+  def self.from_json(value : JSON::PullParser) : Hash(String, String)?
+    if value.kind.begin_object?
+      JSON.parse(value.read_raw).as_h.transform_values(&.to_s)
+    else
+      value.skip
+      nil
+    end
+  end
+
+  def self.to_json(value : Hash(String, String)?, json : JSON::Builder) : Nil
+    value.to_json(json)
+  end
+end
+
+module Data::Package::TolerantArray
+
+  def self.from_json(value : JSON::PullParser) : Array(String)?
+    if value.kind.begin_array?
+      JSON.parse(value.read_raw).as_a.map(&.to_s)
+    else
+      value.skip
+      nil
+    end
+  end
+
+  def self.to_json(value : Array(String)?, json : JSON::Builder) : Nil
+    value.to_json(json)
+  end
+end
+
 class Data::Package
   # Package.json fields #
   # Ref: https://docs.npmjs.com/cli/v9/configuring-npm/package-json
@@ -30,8 +65,11 @@ class Data::Package
     @[YAML::Field(ignore: true)]
     @[MessagePack::Field(ignore: true)]
     property scripts : LifecycleScripts? = nil
+    @[JSON::Field(converter: Data::Package::TolerantArray)]
     getter os : Array(String)? = nil
+    @[JSON::Field(converter: Data::Package::TolerantArray)]
     getter cpu : Array(String)? = nil
+    @[JSON::Field(converter: Data::Package::TolerantHash)]
     getter engines : Hash(String, String)? = nil
     # See: https://github.com/npm/rfcs/blob/main/implemented/0026-workspaces.md
     @[YAML::Field(ignore: true)]

--- a/packages/data/package/package.cr
+++ b/packages/data/package/package.cr
@@ -283,18 +283,6 @@ class Data::Package
     !kind.workspace?
   end
 
-  internal { getter resolved = Atomic(Int8).new(0_i8) }
-
-  # For some dependencies, we need to remember when they have already been resolved
-  # This is to prevent infinite loops when crawling the dependency tree
-  def already_resolved?(state : Commands::Install::State) : Bool
-    if should_resolve_dependencies?(state)
-      !@resolved.compare_and_set(0, 1)[1]
-    else
-      false
-    end
-  end
-
   def self.check_os_cpu_array(field : Array(String)?, value : String)
     # No os/cpu field, no problem
     !field ||

--- a/packages/reporter/interactive.cr
+++ b/packages/reporter/interactive.cr
@@ -1,5 +1,4 @@
 require "log"
-require "term-cursor"
 require "utils/timers"
 require "semver"
 require "./reporter"
@@ -25,9 +24,18 @@ class Reporter::Interactive < Reporter
     @built_packages = Atomic(Int32).new(0)
     @added_packages = Concurrency::SafeSet(String).new
     @removed_packages = Concurrency::SafeSet(String).new
-    @cursor = Term::Cursor
     @debounced_update = Utils::Debounce.new(0.05.seconds) do
       @action.try &.call
+    end
+  end
+
+  # In-house ANSI helpers (replaces the term-cursor shard).
+  private def clear_lines_up(n : Int32) : String
+    String.build do |str|
+      n.times do |i|
+        str << "\e[2K\r"
+        str << "\e[1A" unless i == n - 1
+      end
     end
   end
 
@@ -120,7 +128,7 @@ class Reporter::Interactive < Reporter
 
   def info(str : String) : Nil
     @io_lock.synchronize do
-      @out << %( ℹ #{str.colorize(:blue)}) << Shared::Constants::NEW_LINE
+      @out << %( 💡 #{str.colorize(:blue)}) << Shared::Constants::NEW_LINE
     end
   end
 
@@ -158,7 +166,7 @@ class Reporter::Interactive < Reporter
 
   def prepend(bytes : Bytes) : Nil
     @io_lock.synchronize do
-      @out << @cursor.clear_lines(@lines.get, :up)
+      @out << clear_lines_up(@lines.get)
       @out << String.new(bytes)
       @out << Shared::Constants::NEW_LINE
       @out.flush
@@ -168,7 +176,7 @@ class Reporter::Interactive < Reporter
 
   def prepend(str : String) : Nil
     @io_lock.synchronize do
-      @out << @cursor.clear_lines(@lines.get, :up)
+      @out << clear_lines_up(@lines.get)
       @out << str
       @out << Shared::Constants::NEW_LINE
       @out.flush
@@ -190,7 +198,7 @@ class Reporter::Interactive < Reporter
     packing_header = header("🎁", "Packing…")
     @action = -> do
       output = String.build do |str|
-        str << @cursor.clear_lines(@lines.get, :up)
+        str << clear_lines_up(@lines.get)
         str << resolving_header
         str << %([#{@resolved_packages.get}/#{@resolving_packages.get}])
         @lines.set(1)
@@ -225,7 +233,7 @@ class Reporter::Interactive < Reporter
     @action = -> do
       if @installing_packages.get > 0
         output_sync_unless_stopped do
-          @out << @cursor.clear_line
+          @out << "\e[2K\r"
           @out << installing_header
           @out << %([#{@installed_packages.get}/#{@installing_packages.get}])
           @out.flush
@@ -242,7 +250,7 @@ class Reporter::Interactive < Reporter
     building_header = header("🧱", "Building…", :light_red)
     @action = -> do
       output_sync_unless_stopped do
-        @out << @cursor.clear_line
+        @out << "\e[2K\r"
         @out << building_header
         @out << %([#{@built_packages.get}/#{@building_packages.get}])
         @out.flush

--- a/packages/reporter/shard.lock
+++ b/packages/reporter/shard.lock
@@ -28,10 +28,6 @@ shards:
     path: ../shared
     version: 0.1.0
 
-  term-cursor:
-    git: https://github.com/crystal-term/cursor.git
-    version: 0.1.0+git.commit.8805d5f686d153db92cf2ce3333433f8ed3708d0
-
   utils:
     path: ../utils
     version: 0.1.0

--- a/packages/reporter/shard.yml
+++ b/packages/reporter/shard.yml
@@ -2,8 +2,6 @@
 name: reporter
 version: 0.1.3
 dependencies:
-  term-cursor:
-    github: crystal-term/cursor
   utils:
     path: ../utils
   shared:

--- a/packages/tui/shard.lock
+++ b/packages/tui/shard.lock
@@ -1,0 +1,2 @@
+version: 2.0
+shards: {}

--- a/packages/tui/shard.yml
+++ b/packages/tui/shard.yml
@@ -1,0 +1,4 @@
+name: tui
+version: 0.1.3
+crystalline:
+  main: src/tui.cr

--- a/packages/tui/spec/input_spec.cr
+++ b/packages/tui/spec/input_spec.cr
@@ -1,0 +1,35 @@
+require "./spec_helper"
+
+describe Tui::Input do
+  it "parses arrow key escape sequences" do
+    input = Tui::Input.new(IO::Memory.new("\e[A\e[B\e[C\e[D"))
+    input.next_key.should eq({Tui::Key::Up, 0})
+    input.next_key.should eq({Tui::Key::Down, 0})
+    input.next_key.should eq({Tui::Key::Right, 0})
+    input.next_key.should eq({Tui::Key::Left, 0})
+  end
+
+  it "distinguishes a bare escape from a sequence" do
+    input = Tui::Input.new(IO::Memory.new("\e"))
+    input.next_key.should eq({Tui::Key::Escape, 0})
+  end
+
+  it "parses control keys" do
+    input = Tui::Input.new(IO::Memory.new(" \r\x03"))
+    input.next_key.should eq({Tui::Key::Space, 0})
+    input.next_key.should eq({Tui::Key::Enter, 0})
+    input.next_key.should eq({Tui::Key::CtrlC, 0})
+  end
+
+  it "reports other bytes (letters)" do
+    input = Tui::Input.new(IO::Memory.new("a"))
+    key, byte = input.next_key
+    key.should eq(Tui::Key::Other)
+    byte.should eq(0x61)
+  end
+
+  it "returns Other for end of input" do
+    input = Tui::Input.new(IO::Memory.new(""))
+    input.next_key.should eq({Tui::Key::Other, -1})
+  end
+end

--- a/packages/tui/spec/list_spec.cr
+++ b/packages/tui/spec/list_spec.cr
@@ -55,7 +55,6 @@ describe Tui::List do
   end
 
   it "returns the selected indices from the selection loop" do
-    input = Tui::Input.new(IO::Memory.new(" \e[A \e[B a\r"))
     # a (select all) then enter
     input = Tui::Input.new(IO::Memory.new("a\r"))
     items = [Tui::List::Item.new("x"), Tui::List::Item.new("y")]
@@ -137,4 +136,147 @@ describe Tui::List do
     selected = Tui::List.select([Tui::List::Item.new("x")], input, IO::Memory.new)
     selected.should be_empty
   end
+  it "fuzzy matches by subsequence, case-insensitively" do
+    Tui::List.fuzzy_match?("tlr", "@testing-library/react").should be_true
+    Tui::List.fuzzy_match?("TLR", "@testing-library/react").should be_true
+    Tui::List.fuzzy_match?("xyz", "@testing-library/react").should be_false
+    Tui::List.fuzzy_match?("", "anything").should be_true
+  end
+
+  it "cycles the tag filter and narrows the visible subset" do
+    list = Tui::List.new([
+      Tui::List::Item.new("a", tag: "major"),
+      Tui::List::Item.new("b", tag: "minor"),
+      Tui::List::Item.new("c", tag: "major"),
+    ])
+    list.visible_indices.should eq([0, 1, 2])
+    list.cycle_filter
+    list.visible_indices.should eq([0, 2])
+    list.cycle_filter
+    list.visible_indices.should eq([1])
+    list.cycle_filter
+    list.visible_indices.should eq([0, 1, 2])
+  end
+
+  it "narrows the visible subset with the search text" do
+    list = Tui::List.new([
+      Tui::List::Item.new("react"),
+      Tui::List::Item.new("react-dom"),
+      Tui::List::Item.new("lodash"),
+    ])
+    list.search = "rdom"
+    list.visible_indices.should eq([1])
+  end
+
+  it "maps toggles through the visible subset to full item indices" do
+    list = Tui::List.new([
+      Tui::List::Item.new("a", tag: "major"),
+      Tui::List::Item.new("b", tag: "minor"),
+      Tui::List::Item.new("c", tag: "major"),
+    ])
+    list.cycle_filter # major only
+    list.toggle       # item 0
+    list.selected.should eq(Set{0})
+    list.move(1)      # to item 2 (the second major)
+    list.toggle
+    list.selected.should eq(Set{0, 2})
+  end
+
+  it "selects or clears only the visible items with toggle_all" do
+    list = Tui::List.new([
+      Tui::List::Item.new("a", tag: "major"),
+      Tui::List::Item.new("b", tag: "minor"),
+      Tui::List::Item.new("c", tag: "major"),
+    ])
+    list.cycle_filter # major only
+    list.toggle_all
+    list.selected.should eq(Set{0, 2})
+    list.toggle_all
+    list.selected.should be_empty
+  end
+
+  it "keeps the caret marker on the focused item while scrolling" do
+    items = (0...20).map { |i| Tui::List::Item.new("pkg#{i}") }
+    list = Tui::List.new(items)
+    list.move(15) # scrolls the window to pkg10..pkg19, caret on pkg15
+    io = IO::Memory.new
+    list.render(io, 10)
+    lines = io.to_s.split("\r\n").select { |l| l.includes?("[ ]") }
+    lines.size.should eq(10)
+    lines[5].should start_with("> [ ] pkg15")
+    lines.each_with_index do |line, i|
+      (i == 5).should eq(line.starts_with?("> "))
+    end
+  end
+
+  it "repaints scrolled caret rows at their frame positions" do
+    items = (0...20).map { |i| Tui::List::Item.new("pkg#{i}") }
+    list = Tui::List.new(items)
+    list.move(16) # first = 10, caret at window position 6 (frame row 7)
+    io = IO::Memory.new
+    list.render(io, 10)
+    io.clear
+    list.move(17)
+    list.repaint(io, 10, {16, 17})
+    output = io.to_s
+    # drawn_lines = 12: old caret row 7, new caret row 8, footer row 11.
+    output.should contain("\e[5A\e[2K\r")
+    output.should contain("\e[4A\e[2K\r")
+    output.should contain("\e[1A\e[2K\r")
+  end
+
+  it "exits search mode with backspace on an empty query" do
+    # Search, backspace on the empty query, then space: with the search
+    # exited the space toggles the item instead of extending the query.
+    input = Tui::Input.new(IO::Memory.new("/\x7f "))
+    selected = Tui::List.select([Tui::List::Item.new("x")], input, IO::Memory.new)
+    selected.should eq(Set{0})
+  end
+
+  it "restores the caret to the pre-search item when clearing the search" do
+    items = (0...10).map { |i| Tui::List::Item.new("pkg#{i}") }
+    list = Tui::List.new(items)
+    list.move(5)
+    list.start_search
+    list.cursor.should eq(0)
+    list.clear_search
+    list.cursor.should eq(5)
+  end
+
+  it "repaints the previous caret row when moving during a search" do
+    input = Tui::Input.new(IO::Memory.new("/jest\x1b[B"))
+    io = IO::Memory.new
+    Tui::List.select([
+      Tui::List::Item.new("jest-a"),
+      Tui::List::Item.new("jest-b"),
+      Tui::List::Item.new("jest-c"),
+    ], input, io)
+    last = io.to_s.split("\e[?25l").last
+    # The down repaint must rewrite both the old caret row (5) and the new
+    # one (4); otherwise the old marker lingers and two carets are shown.
+    last.should contain("\e[5A\e[2K\r")
+    last.should contain("\e[4A\e[2K\r")
+  end
+
+  it "toggles the item under the caret while searching" do
+    input = Tui::Input.new(IO::Memory.new("/jest "))
+    selected = Tui::List.select([
+      Tui::List::Item.new("jest-a"),
+      Tui::List::Item.new("jest-b"),
+      Tui::List::Item.new("jest-c"),
+    ], input, IO::Memory.new)
+    selected.should eq(Set{0})
+  end
+
+  it "truncates a long search query so it never wraps" do
+    input = Tui::Input.new(IO::Memory.new("/" + "a" * 300))
+    io = IO::Memory.new
+    Tui::List.select([Tui::List::Item.new("x")], input, io)
+    frames = io.to_s.split("\e[?25l")
+    last = frames.last.gsub(/\e\[[0-9;]*m/, "")
+    line = last.split("\r\n").find { |l| l.starts_with?("  /aaa") }.not_nil!
+    line.should contain("…")
+    line.size.should be < 100
+  end
+
 end

--- a/packages/tui/spec/list_spec.cr
+++ b/packages/tui/spec/list_spec.cr
@@ -1,0 +1,140 @@
+require "./spec_helper"
+
+describe Tui::List do
+  it "moves the cursor and clamps at the edges" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b"), Tui::List::Item.new("c")])
+    list.cursor.should eq(0)
+    list.move(-1)
+    list.cursor.should eq(0)
+    list.move(1)
+    list.cursor.should eq(1)
+    list.move(10)
+    list.cursor.should eq(2)
+  end
+
+  it "toggles the item under the cursor" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b")])
+    list.toggle
+    list.selected.should eq(Set{0})
+    list.toggle
+    list.selected.should be_empty
+  end
+
+  it "toggles between selecting all and none" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b"), Tui::List::Item.new("c")])
+    list.toggle_all
+    list.selected.should eq(Set{0, 1, 2})
+    list.toggle_all
+    list.selected.should be_empty
+  end
+
+  it "renders the window with markers and header" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b")])
+    list.toggle
+    list.move(1)
+    io = IO::Memory.new
+    list.render(io, 10)
+    output = io.to_s
+    output.should contain("Select packages to update")
+    output.should contain("[x] a")
+    output.should contain("[ ] b")
+    output.should contain("> [ ] b") # cursor line
+    output.should contain("1 of 2 selected")
+  end
+
+  it "scrolls the window to keep the cursor visible" do
+    items = (0...20).map { |i| Tui::List::Item.new("pkg#{i}") }
+    list = Tui::List.new(items)
+    list.move(19)
+    io = IO::Memory.new
+    list.render(io, 10)
+    output = io.to_s
+    # The last item is visible and the first is scrolled away.
+    output.should contain("pkg19")
+    output.should_not contain("pkg0")
+  end
+
+  it "returns the selected indices from the selection loop" do
+    input = Tui::Input.new(IO::Memory.new(" \e[A \e[B a\r"))
+    # a (select all) then enter
+    input = Tui::Input.new(IO::Memory.new("a\r"))
+    items = [Tui::List::Item.new("x"), Tui::List::Item.new("y")]
+    selected = Tui::List.select(items, input, IO::Memory.new)
+    selected.should eq(Set{0, 1})
+  end
+
+  it "does not crash when moving on an empty list" do
+    list = Tui::List.new([] of Tui::List::Item)
+    list.move(1)
+    list.cursor.should eq(0)
+  end
+
+  it "clears the previous frame before redrawing" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b")])
+    io = IO::Memory.new
+    list.render(io, 10)
+    io.clear
+    list.move(1)
+    list.render(io, 10)
+    # 4 drawn lines (header + 2 items + footer), cleared upwards from below.
+    output = io.to_s
+    output.should start_with("\e[1A\e[2K\r" * 4)
+  end
+
+  it "truncates long items so they never wrap" do
+    list = Tui::List.new([Tui::List::Item.new("a" * 200)])
+    io = IO::Memory.new
+    list.render(io, 10)
+    item_line = io.to_s.split('\n').find { |l| l.includes?("[ ]") }.not_nil!
+    item_line.size.should be < 200
+    item_line.should contain("…")
+  end
+
+  it "repaints only the affected rows on cursor movement" do
+    list = Tui::List.new([Tui::List::Item.new("a"), Tui::List::Item.new("b"), Tui::List::Item.new("c")])
+    io = IO::Memory.new
+    list.render(io, 10)
+    io.clear
+    list.move(1)
+    list.repaint(io, 10, {0, 1})
+    output = io.to_s
+    # No full-frame clear-and-redraw; just the affected rows rewritten
+    # (frame rows: header at 0, items at 1..N, footer at N+1) and the footer.
+    output.should_not contain("\e[1A\e[2K\r" * 5)
+    output.should contain("\e[4A\e[2K\r")
+    output.should contain("\e[3A\e[2K\r")
+    output.should contain("\e[1A\e[2K\r") # footer row
+  end
+
+  it "renders on the alternate screen and restores it on exit" do
+    input = Tui::Input.new(IO::Memory.new("\r"))
+    io = IO::Memory.new
+    Tui::List.select([Tui::List::Item.new("x")], input, io)
+    output = io.to_s
+    output.should start_with("\e[?1049h")
+    output.should end_with("\e[?1049l")
+  end
+
+  it "truncates by visible columns, keeping ANSI sequences intact" do
+    list = Tui::List.new([Tui::List::Item.new("\e[31m" + "a" * 200 + "\e[0m")])
+    io = IO::Memory.new
+    list.render(io, 10)
+    line = io.to_s.split("\r\n").find { |l| l.includes?("[ ]") }.not_nil!
+    line.should contain("\e[31m")
+    visible = line.gsub(/\e\[[0-9;]*m/, "")
+    visible.size.should be < 200
+    visible.should contain("…")
+  end
+
+  it "stops the selection loop at end of input" do
+    input = Tui::Input.new(IO::Memory.new(""))
+    selected = Tui::List.select([Tui::List::Item.new("x")], input, IO::Memory.new)
+    selected.should be_empty
+  end
+
+  it "returns an empty selection when cancelled" do
+    input = Tui::Input.new(IO::Memory.new("\e"))
+    selected = Tui::List.select([Tui::List::Item.new("x")], input, IO::Memory.new)
+    selected.should be_empty
+  end
+end

--- a/packages/tui/spec/spec_helper.cr
+++ b/packages/tui/spec/spec_helper.cr
@@ -1,0 +1,2 @@
+require "spec"
+require "../src/tui"

--- a/packages/tui/src/tui.cr
+++ b/packages/tui/src/tui.cr
@@ -1,0 +1,3 @@
+require "./tui/ansi"
+require "./tui/input"
+require "./tui/list"

--- a/packages/tui/src/tui/ansi.cr
+++ b/packages/tui/src/tui/ansi.cr
@@ -1,0 +1,46 @@
+module Tui
+  # Minimal ANSI escape sequences (in-house replacement for the term-cursor
+  # shard). Only what the list renderer needs.
+  module Ansi
+    # Clear the current line and return the cursor to the first column.
+    CLEAR_LINE = "\e[2K\r"
+
+    # Move the cursor up *n* lines.
+    def self.move_up(n : Int32) : String
+      "\e[#{n}A"
+    end
+
+    # Move the cursor down *n* lines.
+    def self.move_down(n : Int32) : String
+      "\e[#{n}B"
+    end
+
+    # Clear *n* lines above the cursor. The cursor sits on the line below the
+    # content, so each step moves up then clears: after *n* repetitions the
+    # cleared area is gone and the cursor is at the top of it, ready to
+    # redraw.
+    def self.clear_lines_up(n : Int32) : String
+      "\e[1A\e[2K\r" * n
+    end
+
+    HIDE_CURSOR = "\e[?25l"
+    SHOW_CURSOR = "\e[?25h"
+
+    # Alternate screen buffer: the list renders on a separate screen, and
+    # leaving it restores whatever was on the terminal before, untouched.
+    ENTER_ALT_SCREEN = "\e[?1049h"
+    LEAVE_ALT_SCREEN = "\e[?1049l"
+
+    # Clear the screen and move the cursor to the top-left.
+    CLEAR_SCREEN = "\e[2J\e[H"
+
+    RESET  = "\e[0m"
+    BOLD   = "\e[1m"
+    DIM    = "\e[2m"
+    ITALIC = "\e[3m"
+
+    RED    = "\e[31m"
+    GREEN  = "\e[32m"
+    YELLOW = "\e[33m"
+  end
+end

--- a/packages/tui/src/tui/input.cr
+++ b/packages/tui/src/tui/input.cr
@@ -1,0 +1,91 @@
+module Tui
+  # Keys recognized by the interactive selection loop.
+  enum Key
+    Up
+    Down
+    Left
+    Right
+    Space
+    Enter
+    Escape
+    CtrlC
+    # Any other byte (e.g. plain letters).
+    Other
+  end
+
+  # Reads keys from a terminal in raw mode, using only the standard library.
+  #
+  # The terminal is put in raw mode with `Input#raw`, which must be restored
+  # with the ensure block. `next_key` then returns one key at a time.
+  class Input
+    # Time to wait for the byte following an escape prefix before treating the
+    # escape as a bare Escape key.
+    ESCAPE_SEQUENCE_TIMEOUT = 0.05.seconds
+
+    def initialize(@io : IO = STDIN)
+    end
+
+    # Runs the block with the terminal in raw mode, restoring it afterwards.
+    # Non-terminal IOs (tests) are left untouched.
+    def raw(& : -> T) : T forall T
+      if @io.is_a?(IO::FileDescriptor)
+        io = @io.as(IO::FileDescriptor)
+        io.raw!
+        begin
+          yield
+        ensure
+          io.cooked!
+        end
+      else
+        yield
+      end
+    end
+
+    # Returns the next key and its byte value (only meaningful for Other).
+    def next_key : {Key, Int32}
+      byte = @io.read_byte
+      return {Key::Other, -1} unless byte
+      case byte
+      when 0x1b
+        # Escape alone, or the start of an escape sequence (arrows send \e[X).
+        if (following = read_with_timeout)
+          if following == 0x5b
+            case (code = read_with_timeout)
+            when 0x41 then return {Key::Up, 0}
+            when 0x42 then return {Key::Down, 0}
+            when 0x43 then return {Key::Right, 0}
+            when 0x44 then return {Key::Left, 0}
+            end
+          end
+        end
+        {Key::Escape, 0}
+      when 0x20 then {Key::Space, 0}
+      when 0x0d then {Key::Enter, 0}
+      when 0x03 then {Key::CtrlC, 0}
+      else
+        {Key::Other, byte.to_i32}
+      end
+    end
+
+    # Reads a byte, waiting briefly for the terminal to produce it. On a real
+    # terminal this distinguishes a lone escape from an escape sequence; on
+    # non-terminal IOs (tests) the read is immediate.
+    private def read_with_timeout : UInt8?
+      if @io.is_a?(IO::FileDescriptor)
+        io = @io.as(IO::FileDescriptor)
+        previous_timeout = io.read_timeout
+        io.read_timeout = ESCAPE_SEQUENCE_TIMEOUT
+        begin
+          io.read_byte
+        rescue IO::TimeoutError
+          # A bare Escape: no sequence byte arrived within the timeout.
+          nil
+        ensure
+          io.read_timeout = previous_timeout
+        end
+      else
+        @io.read_byte
+      end
+    end
+  end
+end

--- a/packages/tui/src/tui/list.cr
+++ b/packages/tui/src/tui/list.cr
@@ -1,0 +1,259 @@
+module Tui
+  # `struct winsize` and the ioctl syscall (TIOCGWINSZ), not bound by the
+  # stdlib; used to query the real terminal size.
+  struct Winsize
+    getter ws_row : UInt16 = 0_u16
+    getter ws_col : UInt16 = 0_u16
+    getter ws_xpixel : UInt16 = 0_u16
+    getter ws_ypixel : UInt16 = 0_u16
+  end
+
+  lib LibTui
+    fun ioctl(fd : Int32, request : UInt64, arg : Void*) : Int32
+  end
+
+  # A scrollable multi-select list. The model (items, cursor, selection) is
+  # pure logic; rendering writes ANSI sequences through `Ansi`.
+  class List
+    record Item,
+      label : String,
+      sublabel : String? = nil,
+      # ANSI style prefix applied to the sublabel (e.g. italic+dim). The label
+      # embeds its own styles.
+      sublabel_style : String = ""
+
+    # Height of the visible window, in item rows (excluding header/footer).
+    WINDOW_HEIGHT = 10
+
+    # Terminal width in columns, reported by the kernel when available
+    # (COLUMNS is not always kept in sync by shells). Items are truncated to
+    # it so they never wrap: a wrapped line would corrupt the frame
+    # bookkeeping.
+    private def self.terminal_columns : Int32
+      winsize = Winsize.new
+      if LibTui.ioctl(0, 0x5413_u64, pointerof(winsize).as(Void*)) == 0 && winsize.ws_col > 0
+        winsize.ws_col.to_i32
+      else
+        ENV["COLUMNS"]?.try(&.to_i?) || 80
+      end
+    rescue
+      ENV["COLUMNS"]?.try(&.to_i?) || 80
+    end
+
+    COLUMNS = terminal_columns.clamp(20, 500)
+
+    getter items : Array(Item)
+    getter cursor : Int32 = 0
+    getter selected : Set(Int32) = Set(Int32).new
+
+    def initialize(@items : Array(Item))
+    end
+
+    def move(delta : Int32) : Nil
+      return if @items.empty?
+      @cursor = (@cursor + delta).clamp(0, @items.size - 1)
+    end
+
+    # Toggles the item under the cursor.
+    def toggle : Nil
+      if @selected.includes?(@cursor)
+        @selected.delete(@cursor)
+      else
+        @selected << @cursor
+      end
+    end
+
+    # Selects all items when some are unselected, otherwise clears the
+    # selection (the `a` key).
+    def toggle_all : Nil
+      if @selected.size == @items.size
+        @selected.clear
+      else
+        @items.each_index { |i| @selected << i }
+      end
+    end
+
+    # Runs the selection loop and returns the selected indices (empty when the
+    # user cancels with escape or ctrl-c). The terminal must already be in raw
+    # mode. The first frame is drawn in full; cursor moves and toggles only
+    # repaint the affected rows.
+    def self.select(
+      items : Array(Item),
+      input : Input,
+      io : IO = STDOUT,
+      window_height : Int32 = WINDOW_HEIGHT,
+    ) : Set(Int32)
+      list = new(items)
+      # Render on the alternate screen so the caller's output is restored,
+      # untouched, when the selection loop exits.
+      io << Ansi::ENTER_ALT_SCREEN << Ansi::CLEAR_SCREEN
+      begin
+        list.render(io, window_height)
+        loop do
+          key, byte = input.next_key
+          case key
+          in Key::Up
+            previous = list.cursor
+            list.move(-1)
+            list.repaint(io, window_height, {previous, list.cursor})
+          in Key::Down
+            previous = list.cursor
+            list.move(1)
+            list.repaint(io, window_height, {previous, list.cursor})
+          in Key::Space
+            list.toggle
+            list.repaint(io, window_height, {list.cursor})
+          in Key::Enter
+            break
+          in Key::Escape, Key::CtrlC
+            return Set(Int32).new
+          in Key::Other
+            break if byte == -1 # end of input: stop redrawing
+            if byte == 0x61 # 'a'
+              list.toggle_all
+              list.render(io, window_height)
+            end
+          in Key::Left, Key::Right
+            # Not used by the list.
+          end
+        end
+        list.selected
+      ensure
+        io << Ansi::LEAVE_ALT_SCREEN
+        io.flush
+      end
+    end
+
+    # Renders the visible window, redrawing over whatever was drawn before.
+    def render(io : IO, window_height : Int32 = WINDOW_HEIGHT) : Nil
+      # The cursor sits below the previously drawn area; clear it upwards so
+      # the old content cannot bleed into the new frame.
+      io << Ansi.clear_lines_up(@drawn_lines) if @drawn_lines > 0
+      io << Ansi::HIDE_CURSOR
+      io << header
+      @visible_window = visible_items(window_height)
+      @visible_window.each do |index|
+        io << item_line(index)
+      end
+      io << footer
+      io << Ansi::SHOW_CURSOR
+      @drawn_lines = 2 + @visible_window.size
+      io.flush
+    end
+
+    # Repaints the given item indices in place; falls back to a full redraw
+    # when the visible window scrolled.
+    def repaint(io : IO, window_height : Int32, indices : Enumerable(Int32)) : Nil
+      window = visible_items(window_height)
+      unless window == @visible_window
+        render(io, window_height)
+        return
+      end
+      indices.each do |index|
+        if position = window.index(index)
+          # Frame rows: header at 0, items at 1..N, footer at N+1.
+          draw_row(io, position + 1)
+        end
+      end
+      # The footer carries the selection count, which toggles change.
+      draw_row(io, @visible_window.size + 1)
+      io.flush
+    end
+
+    # Removes the frame from the terminal, leaving the cursor below it.
+    def clear(io : IO) : Nil
+      return if @drawn_lines == 0
+      io << Ansi.clear_lines_up(@drawn_lines)
+      @drawn_lines = 0
+      io.flush
+    end
+
+    # -- private --
+
+    @drawn_lines = 0
+    @visible_window = [] of Int32
+
+    private def header : String
+      visible = "Select packages to update  (up/down move, space select, a all/none, enter upgrade, esc cancel)"
+      # CRLF: in raw mode the output newline translation is off, so a bare \n
+      # moves down without returning to column 0.
+      "  #{Ansi::BOLD}#{truncate(visible, COLUMNS - 3)}#{Ansi::RESET}\r\n"
+    end
+
+    private def footer : String
+      "#{Ansi::DIM}#{@selected.size} of #{@items.size} selected#{Ansi::RESET}\r\n"
+    end
+
+    private def visible_items(window_height : Int32) : Array(Int32)
+      size = @items.size
+      window = Math.min(window_height, size)
+      first = (@cursor - window // 2).clamp(0, size - window)
+      (first...first + window).to_a
+    end
+
+    private def item_line(index : Int32) : String
+      item = @items[index]
+      marker = @cursor == index ? "> " : "  "
+      check = @selected.includes?(index) ? "[x]" : "[ ]"
+      prefix = "#{marker}#{check} "
+      label = truncate(item.label, COLUMNS - prefix.size - 2)
+      if sublabel = item.sublabel
+        remaining = COLUMNS - prefix.size - visible_size(label) - 2
+        sub = truncate(sublabel, remaining)
+        "#{prefix}#{label}  #{item.sublabel_style}#{sub}#{Ansi::RESET}\r\n"
+      else
+        "#{prefix}#{label}\r\n"
+      end
+    end
+
+    # Moves the cursor up to the given frame row, rewrites it in place and
+    # moves back below the frame.
+    private def draw_row(io : IO, row : Int32) : Nil
+      io << Ansi.move_up(@drawn_lines - row)
+      io << Ansi::CLEAR_LINE
+      io << row_content(row)
+      # Back to column 0 on the line below the frame: move_down keeps the
+      # column, so without this the caret would blink at the end of the last
+      # repainted row.
+      io << Ansi.move_down(@drawn_lines - row) << "\r"
+    end
+
+    private def row_content(row : Int32) : String
+      case row
+      when 0
+        header.chomp("\r\n")
+      when @visible_window.size + 1
+        footer.chomp("\r\n")
+      else
+        item_line(@visible_window[row - 1]).chomp("\r\n")
+      end
+    end
+
+    # Truncates text to *max* visible columns, keeping any ANSI SGR sequences
+    # embedded in it intact and closing open styles before the ellipsis.
+    private def truncate(text : String, max : Int32) : String
+      return text if max <= 0
+      visible = 0
+      out = String.build do |str|
+        text.scan(/\e\[[0-9;]*m|./m) do |match|
+          token = match[0]
+          if token.starts_with?('\e')
+            str << token
+          elsif visible < max
+            str << token
+            visible += 1
+          else
+            break
+          end
+        end
+      end
+      return text if out == text
+      "#{out}…#{Ansi::RESET}"
+    end
+
+    # The number of visible columns in *text*, ignoring ANSI sequences.
+    private def visible_size(text : String) : Int32
+      text.gsub(/\e\[[0-9;]*m/, "").size
+    end
+  end
+end

--- a/packages/tui/src/tui/list.cr
+++ b/packages/tui/src/tui/list.cr
@@ -12,65 +12,152 @@ module Tui
     fun ioctl(fd : Int32, request : UInt64, arg : Void*) : Int32
   end
 
-  # A scrollable multi-select list. The model (items, cursor, selection) is
-  # pure logic; rendering writes ANSI sequences through `Ansi`.
+  # A scrollable multi-select list with a fuzzy search (`/`) and a filter
+  # cycle over item tags (`f`). The model is pure logic; rendering writes
+  # ANSI sequences through `Ansi`.
   class List
     record Item,
       label : String,
       sublabel : String? = nil,
       # ANSI style prefix applied to the sublabel (e.g. italic+dim). The label
       # embeds its own styles.
-      sublabel_style : String = ""
+      sublabel_style : String = "",
+      # Optional tag matched by the filter cycle (e.g. the bump severity).
+      tag : String? = nil
 
-    # Height of the visible window, in item rows (excluding header/footer).
+    # Fallback window height, in item rows (excluding header/footer), when
+    # the terminal size cannot be queried.
     WINDOW_HEIGHT = 10
+
+    private def self.terminal_size : {Int32, Int32}
+      winsize = Winsize.new
+      if LibTui.ioctl(0, 0x5413_u64, pointerof(winsize).as(Void*)) == 0
+        {winsize.ws_row.to_i32, winsize.ws_col.to_i32}
+      else
+        {0, 0}
+      end
+    rescue
+      {0, 0}
+    end
 
     # Terminal width in columns, reported by the kernel when available
     # (COLUMNS is not always kept in sync by shells). Items are truncated to
     # it so they never wrap: a wrapped line would corrupt the frame
     # bookkeeping.
-    private def self.terminal_columns : Int32
-      winsize = Winsize.new
-      if LibTui.ioctl(0, 0x5413_u64, pointerof(winsize).as(Void*)) == 0 && winsize.ws_col > 0
-        winsize.ws_col.to_i32
-      else
-        ENV["COLUMNS"]?.try(&.to_i?) || 80
-      end
-    rescue
-      ENV["COLUMNS"]?.try(&.to_i?) || 80
+    COLUMNS = begin
+      rows, cols = terminal_size
+      cols > 0 ? cols.clamp(20, 500) : (ENV["COLUMNS"]?.try(&.to_i?) || 80).clamp(20, 500)
     end
 
-    COLUMNS = terminal_columns.clamp(20, 500)
+    # Window height in item rows, derived from the terminal height minus the
+    # header, the footer and a margin, so the list adapts to the screen.
+    private def self.terminal_height : Int32
+      rows, _ = terminal_size
+      rows > 0 ? (rows - 4).clamp(3, 40) : WINDOW_HEIGHT
+    end
 
     getter items : Array(Item)
-    getter cursor : Int32 = 0
+    # Position of the cursor within the currently visible subset.
+    property cursor : Int32 = 0
+    # Full item indices, independent of the visible subset.
     getter selected : Set(Int32) = Set(Int32).new
+    property search : String = ""
+    property searching : Bool = false
+    getter active_filter : String? = nil
+    # Item the caret was on when the search started; the caret returns there
+    # when the search is cleared (escape, or backspace on an empty query).
+    property search_anchor : Int32? = nil
 
     def initialize(@items : Array(Item))
     end
 
+    # Enters search mode, remembering the item the caret is on so clearing the
+    # search can bring it back.
+    def start_search : Nil
+      @search_anchor = visible_indices[@cursor]?
+      @search = ""
+      @cursor = 0
+      @searching = true
+    end
+
+    # Leaves search mode and restores the caret to the pre-search item.
+    def clear_search : Nil
+      @searching = false
+      @search = ""
+      @cursor = if anchor = @search_anchor
+                  visible_indices.index(anchor) || 0
+                else
+                  0
+                end
+      @search_anchor = nil
+    end
+
+    # The item indices currently visible (search and filter applied).
+    def visible_indices : Array(Int32)
+      @items.each_index.select { |i| visible?(i) }.to_a
+    end
+
+    private def visible?(index : Int32) : Bool
+      item = @items[index]
+      (@search.empty? || self.class.fuzzy_match?(@search, item.label)) &&
+        (@active_filter.nil? || item.tag == @active_filter)
+    end
+
     def move(delta : Int32) : Nil
-      return if @items.empty?
-      @cursor = (@cursor + delta).clamp(0, @items.size - 1)
+      return if visible_indices.empty?
+      @cursor = (@cursor + delta).clamp(0, visible_indices.size - 1)
     end
 
     # Toggles the item under the cursor.
     def toggle : Nil
-      if @selected.includes?(@cursor)
-        @selected.delete(@cursor)
-      else
-        @selected << @cursor
+      if index = visible_indices[@cursor]?
+        if @selected.includes?(index)
+          @selected.delete(index)
+        else
+          @selected << index
+        end
       end
     end
 
-    # Selects all items when some are unselected, otherwise clears the
-    # selection (the `a` key).
+    # Selects all visible items when some are unselected, otherwise clears
+    # the visible selection (the `a` key).
     def toggle_all : Nil
-      if @selected.size == @items.size
-        @selected.clear
-      else
-        @items.each_index { |i| @selected << i }
+      visible = visible_indices
+      all_selected = visible.all? { |i| @selected.includes?(i) }
+      visible.each do |i|
+        if all_selected
+          @selected.delete(i)
+        else
+          @selected << i
+        end
       end
+    end
+
+    # Cycles the tag filter: none -> first tag -> ... -> last tag -> none.
+    def cycle_filter : Nil
+      tags = @items.compact_map(&.tag).uniq.sort
+      return if tags.empty?
+      index = @active_filter ? tags.index(@active_filter).not_nil! : -1
+      next_index = (index + 1) % (tags.size + 1)
+      @active_filter = next_index < tags.size ? tags[next_index] : nil
+      @cursor = 0
+    end
+
+    # Case-insensitive subsequence match (fuzzy): every query character must
+    # appear in order in the text.
+    def self.fuzzy_match?(query : String, text : String) : Bool
+      return true if query.empty?
+      query_chars = query.downcase.chars
+      text_chars = text.downcase.chars
+      i = 0
+      query_chars.each do |c|
+        while i < text_chars.size && text_chars[i] != c
+          i += 1
+        end
+        return false if i >= text_chars.size
+        i += 1
+      end
+      true
     end
 
     # Runs the selection loop and returns the selected indices (empty when the
@@ -81,7 +168,7 @@ module Tui
       items : Array(Item),
       input : Input,
       io : IO = STDOUT,
-      window_height : Int32 = WINDOW_HEIGHT,
+      window_height : Int32 = terminal_height,
     ) : Set(Int32)
       list = new(items)
       # Render on the alternate screen so the caller's output is restored,
@@ -91,6 +178,11 @@ module Tui
         list.render(io, window_height)
         loop do
           key, byte = input.next_key
+          break if byte == -1 # end of input: stop redrawing
+          if list.searching
+            handle_search_key(list, key, byte, io, window_height)
+            next
+          end
           case key
           in Key::Up
             previous = list.cursor
@@ -108,8 +200,13 @@ module Tui
           in Key::Escape, Key::CtrlC
             return Set(Int32).new
           in Key::Other
-            break if byte == -1 # end of input: stop redrawing
-            if byte == 0x61 # 'a'
+            if byte == 0x2f # '/'
+              list.start_search
+              list.render(io, window_height)
+            elsif byte == 0x66 # 'f'
+              list.cycle_filter
+              list.render(io, window_height)
+            elsif byte == 0x61 # 'a'
               list.toggle_all
               list.render(io, window_height)
             end
@@ -124,6 +221,48 @@ module Tui
       end
     end
 
+    # Handles a key while the search line is active.
+    private def self.handle_search_key(list : List, key : Key, byte : Int32, io : IO, window_height : Int32) : Nil
+      case key
+      in Key::Enter
+        list.searching = false
+        list.search_anchor = nil
+        list.render(io, window_height)
+      in Key::Escape
+        list.clear_search
+        list.render(io, window_height)
+      in Key::Up
+        previous = list.cursor
+        list.move(-1)
+        list.repaint(io, window_height, {previous, list.cursor})
+      in Key::Down
+        previous = list.cursor
+        list.move(1)
+        list.repaint(io, window_height, {previous, list.cursor})
+      in Key::Other
+        if byte == 0x7f # backspace
+          if list.search.empty?
+            list.clear_search
+          else
+            list.search = list.search[0...-1]
+            list.cursor = 0
+          end
+          list.render(io, window_height)
+        elsif byte >= 0x20 && byte <= 0x7e
+          list.search += byte.chr
+          list.cursor = 0
+          list.render(io, window_height)
+        end
+      in Key::Space
+        # Toggle the item under the caret; a literal space in the query is
+        # not worth blocking selection on.
+        list.toggle
+        list.repaint(io, window_height, {list.cursor})
+      in Key::Left, Key::Right, Key::CtrlC
+        # Not used while searching.
+      end
+    end
+
     # Renders the visible window, redrawing over whatever was drawn before.
     def render(io : IO, window_height : Int32 = WINDOW_HEIGHT) : Nil
       # The cursor sits below the previously drawn area; clear it upwards so
@@ -132,39 +271,33 @@ module Tui
       io << Ansi::HIDE_CURSOR
       io << header
       @visible_window = visible_items(window_height)
-      @visible_window.each do |index|
-        io << item_line(index)
+      @visible_window.each_with_index do |index, position|
+        io << item_line(index, position)
       end
       io << footer
+      if @searching
+        query = @search.empty? ? "/" : "/#{@search}"
+        io << "  #{Ansi::BOLD}#{truncate(query, COLUMNS - 3)}#{Ansi::RESET}\r\n"
+      end
       io << Ansi::SHOW_CURSOR
-      @drawn_lines = 2 + @visible_window.size
+      @drawn_lines = 2 + @visible_window.size + (@searching ? 1 : 0)
       io.flush
     end
 
-    # Repaints the given item indices in place; falls back to a full redraw
-    # when the visible window scrolled.
-    def repaint(io : IO, window_height : Int32, indices : Enumerable(Int32)) : Nil
+    # Repaints the given cursor positions in place; falls back to a full
+    # redraw when the visible window scrolled.
+    def repaint(io : IO, window_height : Int32, positions : Enumerable(Int32)) : Nil
       window = visible_items(window_height)
       unless window == @visible_window
         render(io, window_height)
         return
       end
-      indices.each do |index|
-        if position = window.index(index)
-          # Frame rows: header at 0, items at 1..N, footer at N+1.
-          draw_row(io, position + 1)
-        end
+      positions.each do |position|
+        row = position - @first + 1
+        draw_row(io, row) if row >= 1 && row <= window.size
       end
       # The footer carries the selection count, which toggles change.
       draw_row(io, @visible_window.size + 1)
-      io.flush
-    end
-
-    # Removes the frame from the terminal, leaving the cursor below it.
-    def clear(io : IO) : Nil
-      return if @drawn_lines == 0
-      io << Ansi.clear_lines_up(@drawn_lines)
-      @drawn_lines = 0
       io.flush
     end
 
@@ -172,28 +305,32 @@ module Tui
 
     @drawn_lines = 0
     @visible_window = [] of Int32
+    @first = 0
 
     private def header : String
-      visible = "Select packages to update  (up/down move, space select, a all/none, enter upgrade, esc cancel)"
-      # CRLF: in raw mode the output newline translation is off, so a bare \n
-      # moves down without returning to column 0.
+      visible = "Select packages to update  (up/down move, space select, a all/none, / search, f filter, enter upgrade, esc cancel)"
       "  #{Ansi::BOLD}#{truncate(visible, COLUMNS - 3)}#{Ansi::RESET}\r\n"
     end
 
     private def footer : String
-      "#{Ansi::DIM}#{@selected.size} of #{@items.size} selected#{Ansi::RESET}\r\n"
+      visible_count = visible_indices.size
+      filter = @active_filter ? " (#{@active_filter})" : ""
+      "#{Ansi::DIM}#{@selected.size} of #{@items.size} selected#{filter}#{Ansi::RESET}\r\n"
     end
 
     private def visible_items(window_height : Int32) : Array(Int32)
-      size = @items.size
-      window = Math.min(window_height, size)
-      first = (@cursor - window // 2).clamp(0, size - window)
-      (first...first + window).to_a
+      visible = visible_indices
+      window = Math.min(window_height, visible.size)
+      @first = (@cursor - window // 2).clamp(0, visible.size - window)
+      visible[@first, window]
     end
 
-    private def item_line(index : Int32) : String
+    private def item_line(index : Int32, position : Int32) : String
       item = @items[index]
-      marker = @cursor == index ? "> " : "  "
+      # The caret row is the cursor's visible-subset position offset by the
+      # window start; comparing against the raw cursor would drift off the
+      # bottom once the window scrolls.
+      marker = position == @cursor - @first ? "> " : "  "
       check = @selected.includes?(index) ? "[x]" : "[ ]"
       prefix = "#{marker}#{check} "
       label = truncate(item.label, COLUMNS - prefix.size - 2)
@@ -225,7 +362,7 @@ module Tui
       when @visible_window.size + 1
         footer.chomp("\r\n")
       else
-        item_line(@visible_window[row - 1]).chomp("\r\n")
+        item_line(@visible_window[row - 1], row - 1).chomp("\r\n")
       end
     end
 

--- a/packages/tui/src/tui/list.cr
+++ b/packages/tui/src/tui/list.cr
@@ -1,6 +1,9 @@
 module Tui
   # `struct winsize` and the ioctl syscall (TIOCGWINSZ), not bound by the
-  # stdlib; used to query the real terminal size.
+  # stdlib; used to query the real terminal size. POSIX-only: on Windows the
+  # ioctl symbol does not exist, so the size falls back to the COLUMNS
+  # environment variable and the default window height.
+  {% unless flag?(:win32) %}
   struct Winsize
     getter ws_row : UInt16 = 0_u16
     getter ws_col : UInt16 = 0_u16
@@ -11,6 +14,7 @@ module Tui
   lib LibTui
     fun ioctl(fd : Int32, request : UInt64, arg : Void*) : Int32
   end
+  {% end %}
 
   # A scrollable multi-select list with a fuzzy search (`/`) and a filter
   # cycle over item tags (`f`). The model is pure logic; rendering writes
@@ -30,12 +34,16 @@ module Tui
     WINDOW_HEIGHT = 10
 
     private def self.terminal_size : {Int32, Int32}
-      winsize = Winsize.new
-      if LibTui.ioctl(0, 0x5413_u64, pointerof(winsize).as(Void*)) == 0
-        {winsize.ws_row.to_i32, winsize.ws_col.to_i32}
-      else
+      {% if flag?(:win32) %}
         {0, 0}
-      end
+      {% else %}
+        winsize = Winsize.new
+        if LibTui.ioctl(0, 0x5413_u64, pointerof(winsize).as(Void*)) == 0
+          {winsize.ws_row.to_i32, winsize.ws_col.to_i32}
+        else
+          {0, 0}
+        end
+      {% end %}
     rescue
       {0, 0}
     end

--- a/packages/utils/misc.cr
+++ b/packages/utils/misc.cr
@@ -1,6 +1,15 @@
 require "concurrency/mutex"
 
 module Utils::Misc
+  # True when --latest may ignore the declared range: a simple rewritable
+  # form (^, ~, <=, >= or exact) without a prerelease. Complex ranges and
+  # prerelease-carrying specifiers stay in-range so a beta is never downgraded.
+  def self.latest_eligible_specifier?(specifier : String) : Bool
+    !specifier.includes?("-") &&
+      (specifier.starts_with?("^") || specifier.starts_with?("~") ||
+       !!specifier.matches?(/\A(<=|>=)?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?\z/))
+  end
+
   def self.parse_key(raw_key : String) : {String, String?}
     split_key = raw_key.split('@')
     if raw_key.starts_with?("@")

--- a/packages/workspaces/spec/workspaces._spec.cr
+++ b/packages/workspaces/spec/workspaces._spec.cr
@@ -157,4 +157,18 @@ describe Workspaces, tags: "workspaces" do
     workspaces.filter("...^[origin/develop]").should eq [WORKSPACE_A]
     workspaces.filter("[origin/develop]^...").should eq [WORKSPACE_B, WORKSPACE_C, WORKSPACE_D]
   end
+  it "accepts bare workspace:^ and workspace:~ specifiers (any version)" do
+    workspaces = Workspaces.new([WORKSPACE_A, WORKSPACE_B])
+    workspaces.get!("a", "workspace:^").should eq(WORKSPACE_A)
+    workspaces.get!("b", "workspace:~").should eq(WORKSPACE_B)
+    workspaces.get!("b", "workspace:").should eq(WORKSPACE_B)
+  end
+
+  it "rejects a workspace: range that does not match the workspace version" do
+    workspaces = Workspaces.new([WORKSPACE_A])
+    expect_raises(Exception, /does not match version/) do
+      workspaces.get!("a", "workspace:^2.0.0")
+    end
+  end
+
 end

--- a/packages/workspaces/workspaces.cr
+++ b/packages/workspaces/workspaces.cr
@@ -106,9 +106,11 @@ class Workspaces
 
   def get!(name : String, version : String) : Workspace
     if workspace = find { |w| w.package.name == name }
-      # The workspace: protocol carries the requested range after the prefix
+      # The workspace: protocol carries the requested range after the prefix;
+      # a bare operator (workspace:^ / workspace:~) matches any version.
       range = version.starts_with?("workspace:") ? version[10..] : version
-      if range.empty? || Semver.parse(range).satisfies?(workspace.package.version)
+      satisfied = range.empty? || range == "^" || range == "~" || Semver.parse(range).satisfies?(workspace.package.version)
+      if satisfied
         workspace
       else
         raise "Workspace #{name} does not match version #{version}"


### PR DESCRIPTION
## Summary

Adds `zap up` (aliases `update`/`upgrade`) for updating dependencies, mirroring npm/yarn/pnpm semantics:

- **`zap up`** — re-resolve dependencies within their declared ranges (lockfile honored for everything else)
- **`zap up --latest`** — bump direct dependencies to their latest version, rewriting `package.json` while preserving the range modifier (`^`, `~`, `<=`, `>=`, exact); prerelease-carrying specifiers stay in-range so a beta is never downgraded
- **`zap up --recursive`** — also re-resolve transitive dependencies
- **`zap up pkg@range`** — update specific packages, optionally to a range
- **`zap up --interactive`** — a zero-dependency in-house TUI (`packages/tui`) listing updateable dependencies on the alternate screen: colored bump-severity squares, fuzzy search (`/`), severity filter (`f`), dynamic window height
- **Negated patterns** (`!pkg`) with pnpm matcher parity; **`npm:` aliases** bump with `--latest` preserving the alias

Plus correctness and performance fixes:

- resolved pins survive `--recursive` re-resolution of shared transitives (isolated linker no longer fails on `name@range`)
- exact transitive-peer marking via a monotone worklist fixpoint (11.2M visits → linear, cycles converge)
- no-op installs no longer re-create workspace/file links or re-walk the whole graph (~3s → ~1s on ledger-live)
- malformed `engines`/`os`/`cpu` metadata tolerated; bare `workspace:^`/`workspace:~` accepted
- ported reference tests from pnpm and yarn berry (globs, negation, aliases, `--no-save`, dist-tags, empty specifiers)

## Verification

- 266 command + 31 tui + 6 workspace specs green, release build clean
- real-world verified on ledger-live (install, `--recursive --latest` update, interactive picker)

Closes #3