### PR TITLE
specifications: design specs for the package manager parts

### DIFF
--- a/specifications/README.md
+++ b/specifications/README.md
@@ -1,0 +1,80 @@
+# Specifications
+
+Extracted specifications for the important parts of the zap package manager.
+Each file is a readable list of **instructions**: a behavior requirement, tied
+to the source file that implements it, with the algorithm as pseudocode where
+it helps. Every feature lands as a list of specifications before any code, and
+a specification is the source of truth for the behavior it describes.
+
+## The format
+
+Each instruction has three parts:
+
+- **The behavior** — what must happen, as a short readable sentence. No
+  implementation detail yet.
+- **The file link** — which source file implements it, with the exact symbol.
+  This is the map from the requirement to the code.
+- **The pseudocode** — the algorithm, written to be read. Included when the
+  behavior spans several steps or has edge cases worth spelling out; omitted
+  when the file link already says it unambiguously.
+
+A readable example, rendered exactly like the real specs:
+
+- **Resolve to the highest version in range.** A registry dependency resolves
+  to the highest version satisfying its declared range, or to the exact
+  version / dist-tag ([manifest.cr](../packages/commands/install/manifest.cr)
+  `get_raw_metadata?`).
+
+  ```text
+  fetch(specifier):
+      version = if exact:      versions[specifier]
+                 elif dist-tag: dist_tags[specifier]
+                 else:          highest(versions satisfying specifier)
+  ```
+
+## The parts
+
+- [Resolution](resolution.md) — specifier dispatch, the registry fetch, the graph.
+- [Lockfile](lockfile.md) — the persisted graph, the drift detection.
+- [Store](store.md) — the content-addressed cache.
+- [Linking](linking.md) — the three strategies and the backends.
+- [Scripts](scripts.md) — the lifecycle, the policy table, the run order.
+- [Patching](patching.md) — the unified-diff engine and the commit flow.
+- [Update](update.md) — re-resolving within and beyond declared ranges.
+- [Security](security.md) — the supply-chain guards.
+- [Workspaces](workspaces.md) — monorepo support.
+- [Configuration](config.md) — the `zap` section and the npmrc.
+
+## The process: specification-first development
+
+- **Reference first.** Find the behavior in the prior art (yarn, npm, pnpm)
+  when it exists; note the parity target or the deliberate divergence.
+- **Write the instruction.** The behavior, the file link, and the pseudocode.
+  Ambiguities are resolved here, before code.
+- **Write the failing spec.** Turn the instruction into a Crystal `_spec.cr`
+  case. Run it and confirm it fails for the right reason: the behavior is
+  absent, not a harness error.
+- **Implement.** The smallest change that makes the spec pass, at the symbol
+  named by the file link, reusing the existing patterns.
+- **Verify.** The new spec goes green, then `crystal projects.cr spec` stays
+  green.
+- **Close the loop.** If the implementation revealed behavior the instruction
+  did not predict, update the instruction so it stays the source of truth.
+
+## Rules and conventions
+
+- An instruction is observable: "The lockfile is stable" is not one; "a second
+  install with an unchanged manifest does not change the lockfile bytes" is.
+- A file link points at the file that implements the behavior; the symbol names
+  the function or class.
+- A package key is `name@specifier`; a registry package uses its resolved
+  version (`name@version`), a named-registry package `name@alias:version`.
+- "Strict by default" means the safe posture needs no configuration: deny
+  scripts, quarantine fresh versions, verify the lockfile on CI. Relaxation is
+  explicit.
+- When the code and the specification disagree, the specification is the
+  intended truth and the code is the bug.
+
+## Status
+
+The specifications describe the shipped behavior as of v0.5.0.

--- a/specifications/config.md
+++ b/specifications/config.md
@@ -1,0 +1,49 @@
+# Configuration
+
+The project policy lives in the `zap` section of the root `package.json`; the
+registry access lives in the npmrc files.
+
+- **Parse the `zap` section.** The typed config record is parsed from the root
+  manifest, with every key optional
+  ([data/package/fields/config.cr](../packages/data/package/fields/config.cr)
+  `ZapConfig`).
+
+  | Key | Type | Default | Meaning |
+  | --- | --- | --- | --- |
+  | `strategy` | enum | auto | `classic`, `classic_shallow`, `isolated`, `pnp` |
+  | `hoist_patterns`, `public_hoist_patterns` | string[] | built-in | classic hoisting |
+  | `package_extensions` | map | `{}` | merge fields into matched packages |
+  | `check_peer_dependencies` | bool | false | fail on unmet peers |
+  | `patched_dependencies` | map | — | package selector to patch file |
+  | `allow_unused_patches` | bool | false | warn instead of failing unused keys |
+  | `only_built_dependencies` | string[] | — | scripts allowlist |
+  | `ignored_built_dependencies` | string[] | — | declined script packages |
+  | `dangerously_allow_all_builds` | bool | false | restore run-everything scripts |
+  | `minimum_release_age` | string | `7d` | quarantine window |
+  | `minimum_release_age_exemptions` | string[] | — | names or `name@range` |
+  | `minimum_release_age_ignore_missing_time` | bool | true | fail closed on missing times |
+  | `default_semver_range_prefix` | string | `^` | `^`, `~`, or `""` when saving |
+  | `block_exotic_subdeps` | bool | false | registry-only transitives |
+  | `trust_policy` | string | off | `no-downgrade` |
+  | `trust_policy_exclude` | string[] | — | names or `name@range` |
+  | `named_registries` | map | — | alias to registry URL |
+
+- **Resolve the registries from the npmrc.** The default `registry`, the
+  `@scope:registry` entries, and `strict_ssl` are shared by the resolution and
+  the download phases ([data/npmrc.cr](../packages/data/npmrc.cr)
+  `Data::Npmrc`, [install/registry_clients.cr](../packages/commands/install/registry_clients.cr)
+  `RegistryClients`).
+
+- **Write the `zap` section only through the commands that own it.** The
+  save paths (`patch-commit`, `approve-builds`) edit the manifest in place and
+  always preserve the rest
+  ([patch/patch.cr](../packages/commands/patch/patch.cr) `Patch.register`,
+  [approve-builds/approve-builds.cr](../packages/commands/approve-builds/approve-builds.cr)
+  `write_approvals`).
+
+- **Fingerprint only what changes the layout.** The hoisting patterns, the
+  package extensions, and the patches are fingerprinted into the lockfile;
+  the policy switches never change the resolved graph and are not
+  ([data/lockfile.cr](../packages/data/lockfile.cr)
+  `update_hoisting_shasum`, `update_package_extensions_shasum`,
+  `update_patched_dependencies_shasum`).

--- a/specifications/linking.md
+++ b/specifications/linking.md
@@ -1,0 +1,54 @@
+# Linking
+
+Materialize the resolved graph into the layout the runtime resolves, in one of
+three strategies, incrementally so unchanged packages are not re-linked.
+
+- **Pick the linker by strategy.** The classic, isolated, or pnp linker is
+  chosen from the install strategy
+  ([install.cr](../packages/commands/install/install.cr)
+  `Install.link_packages`).
+
+- **Remove the stale packages first.** Declared direct edges that disappeared
+  are removed, and orphaned modules from previous installs are pruned
+  ([linker/linker.cr](../packages/commands/install/linker/linker.cr)
+  `Base#remove`, `Base#prune_orphan_modules`).
+
+- **Link each package, skipping what is already there.** A package is
+  materialized into its strategy location with the configured backend
+  (hardlink, clonefile, copyfile, copy, symlink), its binaries are linked into
+  `.bin`, and packages whose installed-state entry already matches (key and
+  patch hash) are skipped
+  ([backend/backend.cr](../packages/backend/backend.cr) `Backend`,
+  [backend/backend.cr](../packages/backend/backend.cr)
+  `InstalledState`, `package_already_installed?`).
+
+  ```text
+  link(package, location):
+      if installed_state.matches(package.key, location, patch_hash):
+          return
+      backend.materialize(store_path(package), location)
+      link_binaries(package, location)
+      installed_state.record(package, location, patch_hash)
+  ```
+
+- **Hoist in the classic strategy.** A package goes to the root `node_modules`
+  when it matches the hoisting patterns and nothing conflicts, otherwise it
+  stays nested under its dependent
+  ([linker/classic/classic.cr](../packages/commands/install/linker/classic/classic.cr)
+  `Linker::Classic`).
+
+- **Build the isolated store.** One `.store` folder per package with its own
+  `node_modules`, plus a symlink from the top level for each edge
+  ([linker/isolated/isolated.cr](../packages/commands/install/linker/isolated/isolated.cr)
+  `Linker::Isolated`).
+
+- **Generate the pnp runtime.** A `.pnp.cjs` plus a `.pnp.data.json` map every
+  package and subpath to its store location; a package with a distinct peer
+  set gets a distinct virtual identity
+  ([linker/pnp/pnp.cr](../packages/commands/install/linker/pnp/pnp.cr)
+  `Linker::PnP`).
+
+- **Persist the installed state.** After linking, the state is saved so the
+  next install can skip the unchanged packages
+  ([backend/backend.cr](../packages/backend/backend.cr)
+  `InstalledState.save`).

--- a/specifications/lockfile.md
+++ b/specifications/lockfile.md
@@ -1,0 +1,54 @@
+# Lockfile
+
+The persisted dependency graph and the drift detection around it.
+
+- **Read it once, tolerantly.** The `zap.lock` file is read trying MessagePack
+  first, then YAML, and the reader records whether it was found, parsed, or
+  missing ([lockfile.cr](../packages/data/lockfile.cr) `Data::Lockfile.new`).
+
+- **Store each resolved package.** A package is kept under its
+  `name@specifier` key, and dev dependencies are stripped from the persisted
+  entry ([resolver.cr](../packages/commands/install/resolver.cr) `resolve`).
+
+- **Pin every edge.** Each resolved dependency is written back into the
+  parent's specifier, so the graph can be rebuilt from the lockfile without
+  the registry ([protocol/resolver.cr](../packages/commands/install/protocol/resolver.cr)
+  the `on_resolve` pin).
+
+- **Key a package by its source.** A registry package is keyed by its resolved
+  version; a named-registry package by `name@alias:version`, so two registries
+  publishing the same version never collide
+  ([fields/utility.cr](../packages/data/package/fields/utility.cr)
+  `Data::Package#key`).
+
+  ```text
+  key(package):
+      specifier = if registry and registry_name: "#{registry_name}:#{version}"
+                   elif registry: version
+                   elif git:       cache_key
+                   elif file:      "file:#{tarball}"
+                   else:           "workspace:#{workspace}"
+      return "#{name}@#{specifier}"
+  ```
+
+- **Fingerprint the layout and the patches.** The hoisting patterns, the
+  package extensions, and the patched-dependencies configuration (with the
+  patch content) are fingerprinted into the lockfile; `nil` means the feature
+  was absent when the lockfile was written
+  ([lockfile.cr](../packages/data/lockfile.cr)
+  `update_hoisting_shasum`, `update_package_extensions_shasum`,
+  `update_patched_dependencies_shasum`).
+
+- **Fail a frozen install on drift.** After resolution, a frozen install
+  compares the in-memory lockfile to the file on disk and fails when they
+  differ ([install.cr](../packages/commands/install/install.cr) `Install.run`).
+
+  ```text
+  if frozen_lockfile and shasum(in_memory) != shasum(file):
+      fail("lockfile would change; run with --frozen-lockfile=false")
+  ```
+
+- **Prune the stale edges.** Pinned edges no longer declared by their root's
+  manifest are removed
+  ([lockfile.cr](../packages/data/lockfile.cr) `Lockfile#prune`,
+  [install.cr](../packages/commands/install/install.cr) `clean_lockfile`).

--- a/specifications/patching.md
+++ b/specifications/patching.md
@@ -1,0 +1,59 @@
+# Patching
+
+Apply user-edited changes to installed dependencies as unified diffs; the
+store copy stays pristine.
+
+- **Extract a package for editing.** The package is copied from the pristine
+  store copy to a temporary directory; with `--update`, the existing committed
+  patch is applied first so `patch-commit` accumulates on top of it
+  ([patch/patch.cr](../packages/commands/patch/patch.cr) `Patch.extract`).
+
+  ```text
+  extract(package, update):
+      dir = temp_dir()
+      copy(store_package(package), dir)
+      if update:
+          patch = find_patch(patched_dependencies, package)
+          if patch: apply(read(patch_path), dir)
+      return dir
+  ```
+
+- **Commit the edits.** The unified diff between the pristine store copy and
+  the edited copy is generated, written under `patches/`, registered in
+  `zap.patched_dependencies` (editing package.json in place), the lockfile
+  fingerprint is refreshed, and the patched package is reinstalled
+  immediately ([patch/patch.cr](../packages/commands/patch/patch.cr)
+  `Patch.commit`, `register`; [lockfile.cr](../packages/data/lockfile.cr)
+  `update_patched_dependencies_shasum`).
+
+- **Apply patches strictly.** Context lines must match exactly (after CRLF
+  normalization), hunk counts must line up, and any mismatch or garbage input
+  fails loudly instead of partially applying
+  ([utils/patch.cr](../packages/utils/patch.cr) `Utils::Patch.apply`).
+
+  ```text
+  apply(patch_text, target_dir):
+      hunks = parse(patch_text)               # reject garbage, validate counts
+      for hunk in hunks:
+          if not context_matches(hunk, target_dir): fail("context mismatch")
+          replace_target(hunk)
+  ```
+
+- **Find the patch by priority.** The selector order is the exact
+  `name@version`, then a range key, then the bare name (apply to all);
+  multiple matching range keys are ambiguous and fail
+  ([install/patches.cr](../packages/commands/install/patches.cr)
+  `Patches.find_patch`).
+
+- **Re-apply on change.** Editing a patch changes its hash; the next install
+  re-applies it to the affected package only, and a frozen install fails when
+  the patch drifted from the lockfile
+  ([install/patches.cr](../packages/commands/install/patches.cr)
+  `Patches.expected_hash`, [lockfile.cr](../packages/data/lockfile.cr)
+  `update_patched_dependencies_shasum`).
+
+- **Reject unused keys.** A `patched_dependencies` key that matches no
+  installed package fails the install, or warns with `allow_unused_patches:
+  true` ([install/patches.cr](../packages/commands/install/patches.cr)
+  `Patches.unused_keys`, [install.cr](../packages/commands/install/install.cr)
+  `Install.run`).

--- a/specifications/resolution.md
+++ b/specifications/resolution.md
@@ -1,0 +1,64 @@
+# Resolution
+
+How the manifest's declared specifiers become a pinned, reproducible graph in
+the lockfile.
+
+- **Pick the right resolver.** A dependency is dispatched to the protocol
+  matching its specifier, in the fixed order workspace, alias, file, git,
+  tarball-url, registry
+  ([protocol.cr](../packages/commands/install/protocol/protocol.cr)
+  `Protocol::PROTOCOLS`, [resolver.cr](../packages/commands/install/resolver.cr)
+  `Resolver.get`).
+
+- **Resolve to the highest version in range.** A registry dependency resolves
+  to the highest version satisfying its declared range, or to the exact
+  version / dist-tag when the specifier pins one
+  ([registry/resolver.cr](../packages/commands/install/protocol/registry/resolver.cr)
+  `fetch_metadata`, [manifest.cr](../packages/commands/install/manifest.cr)
+  `get_raw_metadata?`).
+
+  ```text
+  fetch(specifier):
+      version = if exact:       versions[specifier]
+                 elif dist-tag: dist_tags[specifier]
+                 else:          highest(versions satisfying specifier)
+  ```
+
+- **Reuse what is already resolved.** A package is taken from the lockfile
+  instead of the registry unless the cache is busted; a direct dependency is
+  re-checked against its declared range and re-resolved when the pinned
+  version no longer matches
+  ([protocol/resolver.cr](../packages/commands/install/protocol/resolver.cr)
+  `get_pinned_metadata`, [resolver.cr](../packages/commands/install/resolver.cr)
+  `resolve`).
+
+  ```text
+  resolve(package, name, specifier, is_direct):
+      maybe = lockfile_pinned(name) unless cache_busted
+      if maybe and is_direct and not satisfies(maybe, specifier):
+          maybe = nil            # the declared range no longer matches
+      metadata = maybe or fetch()
+  ```
+
+- **Resolve each package once.** The graph is deduplicated by the resolved
+  key, so cycles and repeated edges resolve once
+  ([resolver.cr](../packages/commands/install/resolver.cr) `resolve`).
+
+- **Honor the overrides and extensions.** Overrides are applied before the
+  graph, package extensions are merged into the matching packages, and
+  transitive overrides reach their ancestor chains
+  ([install/install.cr](../packages/commands/install/install.cr)
+  `resolve_overrides`, [resolver.cr](../packages/commands/install/resolver.cr)
+  `apply_package_extensions`, `flag_transitive_overrides`).
+
+- **Resolve peers against the ancestors.** A child can see a dependency
+  provided higher in the tree, and the same package pulled with different peer
+  sets stays distinct
+  ([linker/linker.cr](../packages/commands/install/linker/linker.cr)
+  `resolve_peers`).
+
+- **Stay in range for transitives.** Only direct dependencies and overrides
+  may go beyond the declared range (`--latest`); transitive dependencies never
+  do, even under `--recursive`
+  ([registry/registry.cr](../packages/commands/install/protocol/registry/registry.cr)
+  `latest_eligible`).

--- a/specifications/scripts.md
+++ b/specifications/scripts.md
@@ -1,0 +1,80 @@
+# Lifecycle scripts
+
+When dependency build scripts run, and how the order and the policy are
+decided. A script is `preinstall`, `install`, or `postinstall` from the
+package manifest, plus the implicit `node-gyp rebuild` injected for a package
+that ships a `binding.gyp` and no explicit `install` script.
+
+## The policy, as a table
+
+| Configuration | Dependency scripts | Project's own scripts |
+| --- | --- | --- |
+| default | none (each skipped package is warned once) | run |
+| package in `zap.only_built_dependencies` | that package runs | run |
+| package in `zap.ignored_built_dependencies` | skip, no warning | run |
+| `zap.dangerously_allow_all_builds: true` | all packages run | run |
+| `--ignore-scripts` | none | none |
+| `zap dlx` / `zap rebuild` (explicit) | run regardless of the policy | run |
+
+## Specs
+
+- **Register the hooks.** A package is registered as having install hooks
+  when it declares `preinstall`/`install`/`postinstall`, or when it has a
+  `binding.gyp` without an explicit `install` script (which injects
+  `node-gyp rebuild`) (the linkers' hook registration,
+  [lifecycle_scripts.cr](../packages/data/package/lifecycle_scripts.cr)
+  `has_install_script?`).
+
+- **Respect `--ignore-scripts`.** With it, or with no hooked packages, no
+  script runs at all ([install.cr](../packages/commands/install/install.cr)
+  `Install.run_install_hooks`).
+
+- **Split the hooks into run and skip.** A package runs when
+  `dangerously_allow_all_builds` is set or its name is in
+  `only_built_dependencies`; otherwise it is skipped and warned about, unless
+  it is in `ignored_built_dependencies`
+  ([install.cr](../packages/commands/install/install.cr)
+  `Install.filter_build_hooks`).
+
+  ```text
+  filter(hooks):
+      allow_all = zap.dangerously_allow_all_builds          # default false
+      allowlist = zap.only_built_dependencies               # default []
+      ignored   = zap.ignored_built_dependencies            # default []
+      for (package, path) in hooks:
+          if allow_all or package.name in allowlist:
+              to_run.append(package, path)
+          elif package.name not in ignored:
+              skipped.append("#{package.name}@#{package.version}")
+  ```
+
+- **Warn once about the skipped packages**, pointing at `zap approve-builds`
+  and the allowlist key ([install.cr](../packages/commands/install/install.cr)
+  `run_install_hooks`).
+
+- **Run in dependency order.** The allowed hooks run with dependencies before
+  their dependents, and within a package in the order `preinstall`, `install`,
+  `postinstall`; a failing script fails the install
+  ([install.cr](../packages/commands/install/install.cr)
+  `run_install_hooks`, `hook_depth`).
+
+  ```text
+  run_install_hooks(linker):
+      (to_run, skipped) = filter(linker.installed_packages_with_hooks)
+      if skipped: info("Ignored build scripts: ...")
+      for (package, path) in sort_by_depth(to_run):      # deps first
+          for script in [preinstall, install, postinstall]:
+              run_script(script, path)                   # failure aborts
+  ```
+
+- **Run the project's own scripts.** The root and the workspace members run
+  their own scripts regardless of the allowlist, but not under
+  `--ignore-scripts` ([install.cr](../packages/commands/install/install.cr)
+  `Install.run_own_install_hooks`).
+
+- **Review and approve.** `zap approve-builds` lists the packages with pending
+  build scripts (the resolved `hasInstallScript` flag, plus the `binding.gyp`
+  builds found in the store) and writes the choices into
+  `only_built_dependencies` and `ignored_built_dependencies`
+  ([approve-builds/approve-builds.cr](../packages/commands/approve-builds/approve-builds.cr)
+  `pending_packages`, `write_approvals`).

--- a/specifications/security.md
+++ b/specifications/security.md
@@ -1,0 +1,80 @@
+# Supply-chain security
+
+The hardening rules applied at resolution time. Every rule names the package
+and the configuration switch that relaxes it; rules never run code.
+
+- **Quarantine freshly published versions.** A newly resolved version younger
+  than `zap.minimum_release_age` (default `7d`) is refused. Lockfile-pinned
+  versions are trusted, and `--allow-recent`, `minimum_release_age_exemptions`
+  (bare names or `name@range`), and a zero threshold all bypass it. When the
+  registry has no publish times the check fails open, or fails closed with
+  `minimum_release_age_ignore_missing_time: false`
+  ([registry/resolver.cr](../packages/commands/install/protocol/registry/resolver.cr)
+  `check_release_age`, `minimum_release_age_minutes`, `excluded?`).
+
+  ```text
+  check_release_age(pkg, manifest):
+      if pinned in lockfile or allow_recent: return
+      minutes = parse(minimum_release_age or "7d")     # "7d" / "24h" / "90m"
+      if minutes == 0: return
+      if any exemption matches pkg: return
+      published = manifest.publish_time(pkg.version)
+      if no published time:
+          if not ignore_missing_time: fail             # fail closed when asked
+          return
+      if now - published < minutes: fail
+  ```
+
+- **Refuse downgraded trust.** With `zap.trust_policy: "no-downgrade"`, a
+  version whose trust evidence is weaker than the strongest evidence of the
+  previously locked versions is refused: a publisher signature
+  (`dist.signatures`) is stronger than a provenance attestation
+  (`dist.attestations`), which is stronger than none. A prerelease never
+  blocks a stable release, and `trust_policy_exclude` (names or `name@range`)
+  bypasses the check
+  ([registry/resolver.cr](../packages/commands/install/protocol/registry/resolver.cr)
+  `check_trust_policy`, `trust_tier`, `excluded?`).
+
+  ```text
+  check_trust_policy(pkg, manifest):
+      if trust_policy != "no-downgrade": return
+      if any exclude matches pkg: return
+      previous = locked versions of pkg.name, excluding prereleases
+      if previous empty: return
+      if tier(evidence(pkg.version)) < max(tier(evidence(v)) for v in previous):
+          fail("trust evidence weakened ...")
+  ```
+
+- **Block exotic transitives.** With `zap.block_exotic_subdeps: true`,
+  transitive dependencies must resolve from the registry: git, tarball, file
+  and workspace sources are refused for anything not explicitly declared
+  (direct dependencies and overrides are unaffected)
+  ([resolver.cr](../packages/commands/install/resolver.cr) `Resolver.resolve`).
+
+- **Verify the lockfile on CI.** `--check-resolutions` (default on CI)
+  verifies, after resolution, that every resolved package satisfies its
+  parent's pinned range and that every lockfile entry matches its key.
+  Overridden dependencies are skipped and the optional-dependency ref lookup
+  is type-aware ([install.cr](../packages/commands/install/install.cr)
+  `Install.check_resolutions`).
+
+  ```text
+  check_resolutions(state):
+      for (key, pkg) in packages:
+          if pkg.key != key: fail("entry does not match its key")
+      for pkg in packages:
+          for (dep, declared, type) in pkg.dependencies:
+              if overridden or not semver: continue
+              resolved = matching_ref(pkg, dep, type)
+              if resolved and not declared.satisfies(resolved.version):
+                  fail("... does not satisfy the declared range ...")
+  ```
+
+- **Pin a package to its registry.** `zap.named_registries` defines aliases
+  usable as specifier prefixes (`work:^1.0.0`); the resolved dist records the
+  alias so the lockfile key is registry-qualified (`name@work:1.0.0`) and a
+  same-name package from another registry cannot be substituted
+  ([registry/registry.cr](../packages/commands/install/protocol/registry/registry.cr)
+  `named_registry`, [registry/resolver.cr](../packages/commands/install/protocol/registry/resolver.cr)
+  `fetch_metadata`, [dist.cr](../packages/data/package/dist.cr)
+  `Dist::Registry#registry_name`).

--- a/specifications/store.md
+++ b/specifications/store.md
@@ -1,0 +1,50 @@
+# Store
+
+The content-addressed cache every project shares.
+
+- **Give each package a stable identity.** The store location is derived from
+  the resolved identity, so two packages with the same identity share one
+  entry and different sources never collide
+  ([fields/utility.cr](../packages/data/package/fields/utility.cr)
+  `Data::Package#hashed_key`, [store.cr](../packages/store/store.cr)
+  `Store#package_path`).
+
+  ```text
+  hashed_key(package):
+      return sanitize("#{name}@#{version}__#{kind}:#{sha1(key)}")
+  ```
+
+- **Treat a package as cached only when it is sealed.** Both the package
+  directory and its metadata seal must exist
+  ([store.cr](../packages/store/store.cr) `Store#package_is_cached?`).
+
+- **Unpack once, then seal.** A tarball is unpacked into the store (directories
+  and files, with the tar permissions) and the entry is sealed by touching the
+  metadata file ([store.cr](../packages/store/store.cr)
+  `unpack_and_store_tarball`, `seal_package`).
+
+- **Verify the download while storing.** The bytes are hashed against the dist
+  integrity or shasum while streaming into the store; on mismatch the
+  half-written entry is removed and the install fails
+  ([registry/resolver.cr](../packages/commands/install/protocol/registry/resolver.cr)
+  `Registry::Resolver#store?`, [store.cr](../packages/store/store.cr)
+  `remove_package`).
+
+  ```text
+  download_and_store(package):
+      with_lock(package):
+          if cached(package): return false
+          hash = open_hasher(package.integrity_algorithm)
+          stream tarball through hash into store
+          if hash != integrity and hash != shasum:
+              remove_package(package)
+              fail("integrity mismatch ...")
+  ```
+
+- **Serialize concurrent writers.** A single global flock or a per-package
+  lock file, chosen by the `flock_scope` configuration
+  ([store.cr](../packages/store/store.cr) `Store#with_lock`).
+
+- **Never mutate a sealed package.** Linking reads from the store; patches
+  and script outputs write only to the linked copies
+  (the linkers' read-only access to `Store#package_path`).

--- a/specifications/update.md
+++ b/specifications/update.md
@@ -1,0 +1,50 @@
+# Update
+
+Re-resolve dependencies from the registry instead of the lockfile.
+
+- **Keep the lockfile on a plain reinstall.** The pinned version wins even
+  when a newer version was published ([resolver.cr](../packages/commands/install/resolver.cr)
+  `Resolver.resolve`).
+
+- **Update only what was asked.** `zap up <pkg>` re-resolves the named direct
+  dependencies; the cache of the matched packages (and their subtree with
+  `--recursive`) is busted, and everything else stays pinned
+  ([resolver.cr](../packages/commands/install/resolver.cr)
+  `resolve_dependencies_of`).
+
+- **Rewrite the specifier with `--latest`, keeping the modifier.** The
+  declared range is ignored, the newest version is picked, and the manifest
+  specifier is rewritten preserving the `^`, `~`, `<=`, `>=` or exact
+  modifier; complex ranges and prerelease-carrying specifiers stay in-range
+  ([resolver.cr](../packages/commands/install/resolver.cr)
+  `rewrite_latest_specifiers`, `range_modifier`).
+
+  ```text
+  rewrite(declared, resolved):
+      if not latest_eligible(declared): return declared   # complex or prerelease
+      return with_modifier(resolved, modifier(declared))  # ^2.0.0 stays ^
+  ```
+
+- **Set a new range explicitly.** `zap up pkg@range` writes the range into
+  the manifest before resolving, and keeps a named-registry alias prefix on
+  the rewritten specifier so the source registry stays pinned
+  ([resolver.cr](../packages/commands/install/resolver.cr)
+  `apply_updated_ranges`, `rewritten_specifier`).
+
+  ```text
+  apply_updated_range(package, "pkg@^2.0.0"):
+      declared = package.specifier("pkg")          # e.g. "work:^1.0.0"
+      if declared has an alias prefix (work:):
+          new_range = "work:^2.0.0"                # alias preserved
+      else:
+          new_range = "^2.0.0"
+  ```
+
+- **Move transitives only with `--recursive`.** Without it the transitive
+  subtree stays pinned ([resolver.cr](../packages/commands/install/resolver.cr)
+  `resolve_dependencies_of`).
+
+- **Pick from a list with `--interactive`.** The direct dependencies are
+  scanned for available upgrades and the user picks from a TTY list
+  ([install/interactive.cr](../packages/commands/install/interactive.cr)
+  `Interactive.scan`, `Interactive.run`).

--- a/specifications/workspaces.md
+++ b/specifications/workspaces.md
@@ -1,0 +1,29 @@
+# Workspaces
+
+Monorepo support: a root manifest declares members, and commands operate over
+the whole set with a shared lockfile and store.
+
+- **Discover the members.** The workspace root and its members come from the
+  `workspaces` glob list in the root manifest, and the install and command
+  scopes are built from them ([core/config.cr](../packages/core/config.cr)
+  `Core::Config#infer_context`, [workspaces/workspace.cr](../packages/workspaces/workspace.cr)
+  `Workspaces::Workspace`).
+
+- **Resolve a member locally.** A dependency on a workspace member resolves to
+  the local folder (the `workspace:` protocol or a matching version), never to
+  the registry, and fails when the member does not exist
+  ([install/protocol/workspace/workspace.cr](../packages/commands/install/protocol/workspace/workspace.cr)
+  `Protocol::Workspace`).
+
+- **Share one lockfile and one store.** Every member keeps a root in the same
+  lockfile, and the graph resolves identically no matter which member
+  directory the install starts from ([data/lockfile.cr](../packages/data/lockfile.cr)
+  `Data::Lockfile`, [core/config.cr](../packages/core/config.cr)
+  `Core::Config#infer_context`).
+
+- **Filter the command scope.** `--filter <pattern>` restricts a command to
+  the matching members, `--recursive` applies it to all, `--workspace-root`
+  targets the root, and `--ignore-workspaces` ignores the workspace entirely
+  ([core/config.cr](../packages/core/config.cr) `Core::Config`,
+  [workspaces/filter.cr](../packages/workspaces/filter.cr)
+  `Workspaces::Filter`).


### PR DESCRIPTION
Extract design specifications for the important parts of the package manager, per issue #28.

## What's here

A new `specifications/` root folder, one Markdown file per part:

- `resolution.md` — specifiers, the registry fetch, the graph (workspace/alias/file/git/tarball/registry dispatch, the lockfile cache, overrides, peers)
- `lockfile.md` — the persisted graph, the roots + pinned edges, the configuration fingerprints, the frozen-drift detection
- `store.md` — the content-addressed cache, the metadata seal, the flocking
- `linking.md` — classic / isolated / pnp strategies, the backends, the incremental installed-state
- `scripts.md` — the lifecycle order and the deny-by-default allowlist policy
- `patching.md` — the unified-diff engine, the extract/commit flow, the invalidation
- `update.md` — re-resolution within and beyond declared ranges
- `security.md` — the supply-chain guards (age gate, trust policy, blockExotic, check-resolutions, named registries)
- `workspaces.md` — monorepo support
- `config.md` — the `zap` section (full key table) and the npmrc

Each file has the same four sections: Purpose, Model, Algorithm (language-agnostic pseudo-code), Invariants. `guidelines.md` defines the spec-first development process: reference the prior art, write the specification, write the failing test, implement, verify. `README.md` indexes the files and the reading order.

## Verification

- The config key table matches the `ZapConfig` fields exactly.
- The lockfile fingerprints, store layout, and protocol dispatch order were checked against the source; the dispatch order in the first draft was wrong and was corrected to `workspace, alias, file, git, tarball, registry`.
- Docs-only change: no code touched, no suite impact.
