### PR TITLE
approve-builds: run the hooks of the approved packages immediately

### DIFF
--- a/packages/commands/approve-builds/approve-builds.cr
+++ b/packages/commands/approve-builds/approve-builds.cr
@@ -1,6 +1,10 @@
 require "json"
 require "tui"
 require "data/lockfile"
+require "backend/backend"
+require "shared/constants"
+require "../install/install"
+require "../install/config"
 
 module Commands::ApproveBuilds
   # `zap approve-builds`: review the dependencies that declare build scripts
@@ -35,13 +39,36 @@ module Commands::ApproveBuilds
     approved = selected.map { |index| pending[index].name }
     declined = pending.map(&.name).reject { |name| approved.includes?(name) }
 
-    write_approvals(context.config.prefix, approved, declined)
+    apply_approvals(context, approved, declined)
 
     puts "Approved: #{approved.sort.join(", ")}" unless approved.empty?
     puts "Ignored: #{declined.sort.join(", ")}" unless declined.empty?
   rescue ex : Exception
     puts ex.message
     exit 1
+  end
+
+  # Writes the decisions and re-links the newly approved packages so their
+  # build scripts run right away instead of waiting for a future install.
+  def self.apply_approvals(context : Core::Config::InferredContext, approved : Array(String), declined : Array(String)) : Nil
+    previously_allowed = context.main_package.zap_config.try(&.only_built_dependencies) || [] of String
+    write_approvals(context.config.prefix, approved, declined)
+
+    newly_approved = approved.reject { |name| previously_allowed.includes?(name) }
+    return if newly_approved.empty?
+
+    lockfile = Data::Lockfile.new(context.config.prefix)
+    keys = lockfile.packages.values.select { |pkg| newly_approved.includes?(pkg.name) }.map(&.key)
+    return if keys.empty?
+
+    # Invalidate the installed-state entries so the reinstall re-links the
+    # packages, which registers their hooks; the allowlist now admits them.
+    state_path = Path.new(context.config.node_modules) / Shared::Constants::STATE_FILE_NAME
+    installed_state = Backend::InstalledState.load(state_path)
+    installed_state.reject! { |_path, entry| keys.includes?(entry.key) }
+    Backend::InstalledState.save(state_path, installed_state)
+
+    Commands::Install.run(context.config, Commands::Install::Config.new.copy_with(frozen_lockfile: false), raise_on_failure: true)
   end
 
   # The packages with install scripts that are neither allowlisted nor

--- a/packages/commands/spec/install/integration/approve_builds._spec.cr
+++ b/packages/commands/spec/install/integration/approve_builds._spec.cr
@@ -109,6 +109,35 @@ describe "approve-builds", tags: "integration" do
     end
   end
 
+  it "re-links the approved packages so their scripts run" do
+    It.with_registry do |registry|
+      registry.add("scripted", "1.0.0", It.pkg("scripted", "1.0.0",
+        scripts: {"install" => "node -e \"require('fs').writeFileSync('order.txt','ok')\""}),
+        {"index.js" => "s"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"scripted":"1.0.0"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # The install blocked the script (no allowlist)
+        File.exists?(tmpdir / "node_modules/scripted/order.txt").should be_false
+
+        Commands::ApproveBuilds.apply_approvals(config.infer_context, ["scripted"], [] of String)
+
+        # The config is written, the package re-linked, and its script ran
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["zap"]["only_built_dependencies"].as_a.map(&.as_s).should eq(["scripted"])
+        File.exists?(tmpdir / "node_modules/scripted/order.txt").should be_true
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
   it "persists the decisions into the zap section of package.json" do
     tmpdir = Path.new(Dir.tempdir, "zap-ab-#{Random::Secure.hex(4)}")
     begin


### PR DESCRIPTION
Fix for the approve-builds gap: approving a package wrote the allowlist but never ran the build scripts.

## The fix

`zap approve-builds` now calls `apply_approvals` after the review:

1. The decisions are written to `zap.only_built_dependencies` / `ignored_built_dependencies` as before.
2. The installed-state entries of the **newly approved** packages are invalidated (already-allowlisted names are skipped).
3. A reinstall runs immediately, which re-links exactly those packages and executes their hooks — the allowlist now admits them.

This mirrors `patch-commit`, which re-installs the patched package right away. The approvals persist even if a re-link fails (the config write comes first).

## Verification

- New spec: install a scripted package (scripts blocked) → `apply_approvals(["scripted"])` → the config is written and the script's marker file appears.
- 342 commands specs, 914+ across all 8 packages, 0 failures.
