### PR TITLE
install: support the catalog: protocol (pnpm / yarn parity)

### DIFF
--- a/packages/commands/install/linker/linker.cr
+++ b/packages/commands/install/linker/linker.cr
@@ -107,6 +107,9 @@ module Commands::Install::Linker
     # for *name*. Mirrors yarn's behavior of preferring a satisfiable peer
     # over a same-name regular dependency.
     protected def peer_satisfied_by_ancestor?(name : String, peer_range : String, ancestors : Enumerable(Data::Package | Data::Lockfile::Root)) : Bool
+      if peer_range.starts_with?("catalog:")
+        peer_range = Commands::Install::Resolver.expand_catalog(name, peer_range, state)
+      end
       range = Semver.parse?(peer_range) || Semver::ANY
       satisfied = false
       ancestors.each do |ancestor|
@@ -125,6 +128,9 @@ module Commands::Install::Linker
       peers = Hash(String, Set(Semver::Range)).new
       if direct_peers = package.peer_dependencies
         direct_peers.each do |direct_peer, peer_range|
+          if peer_range.starts_with?("catalog:")
+            peer_range = Commands::Install::Resolver.expand_catalog(direct_peer, peer_range, state)
+          end
           peers[direct_peer] = Set(Semver::Range){
             Semver.parse?(peer_range).or(Semver::ANY),
           }

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -145,13 +145,32 @@ module Commands::Install::Resolver
 
   # The rewritten specifier keeps a named registry alias prefix (work:^1.0.0
   # becomes work:^2.0.0): the alias pins the source registry, and dropping it
-  # would silently re-point the dependency at the default registry.
+  # would silently re-point the dependency at the default registry. The npm:
+  # and catalog: prefixes are not registry aliases and are written literally.
   private def self.rewritten_specifier(declared : (String | Data::Package::Alias)?, range : String) : String
-    if declared.is_a?(String) && (match = declared.match(/\A([A-Za-z0-9._-]+):/)) && match[1] != "npm"
+    if declared.is_a?(String) && (match = declared.match(/\A([A-Za-z0-9._-]+):/)) && match[1] != "npm" && match[1] != "catalog"
       "#{match[1]}:#{range}"
     else
       range
     end
+  end
+
+  # The catalog protocol (pnpm / yarn parity): "catalog:" resolves to the
+  # entry for the dependency in the default catalog, "catalog:<name>" to the
+  # entry in the named catalog. The value is returned as a regular specifier.
+  def self.expand_catalog(name : String, specifier : String, state : Commands::Install::State) : String
+    zap = state.context.main_package.zap_config
+    catalog_name = specifier == "catalog:" ? "default" : specifier[8..]
+    entries =
+      if catalog_name == "default"
+        zap.try(&.catalog)
+      else
+        zap.try(&.catalogs).try(&.[catalog_name]?)
+      end
+    unless entries
+      raise "The catalog \"#{catalog_name}\" referenced by #{name} is not defined. Define it under zap.catalog or zap.catalogs in the root package.json."
+    end
+    entries[name]? || raise "The catalog \"#{catalog_name}\" has no entry for #{name}."
   end
 
   # With --latest, rewrites the declared specifier of updated direct
@@ -257,6 +276,12 @@ module Commands::Install::Resolver
   )
     Log.debug { "(#{name}@#{version}) Resolving package…" + (type ? " [type: #{type}]" : "") + (package ? " [parent: #{package.key}]" : "") }
     state.reporter.on_resolving_package
+    # The catalog protocol (pnpm / yarn parity): a "catalog:" specifier
+    # resolves to the range defined at the workspace root before the
+    # protocol dispatch, so it behaves like a regular specifier.
+    if version.starts_with?("catalog:")
+      version = expand_catalog(name, version, state)
+    end
     # Add direct dependencies to the lockfile
     if package && is_direct_dependency && type
       state.lockfile.add_dependency(name, version, type, package.name, package.version)

--- a/packages/commands/spec/install/integration/catalog._spec.cr
+++ b/packages/commands/spec/install/integration/catalog._spec.cr
@@ -1,0 +1,240 @@
+require "./spec_helper"
+
+# The catalog: protocol (pnpm / yarn berry parity): a dependency specifier
+# resolves to the version range defined once at the workspace root.
+describe "catalogs", tags: "integration" do
+  it "resolves the default catalog reference to its range" do
+    It.with_registry do |registry|
+      registry.add("react", "17.0.2", It.pkg("react", "17.0.2"), {"index.js" => "17.0.2"})
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}})) do |project|
+        # catalog: is the shorthand for catalog:default
+        File.read(project / "node_modules/react/index.js").should eq("18.3.1")
+      end
+    end
+  end
+
+  it "resolves a named catalog reference" do
+    It.with_registry do |registry|
+      registry.add("react", "17.0.2", It.pkg("react", "17.0.2"), {"index.js" => "17.0.2"})
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:react17"},"zap":{"catalogs":{"react17":{"react":"^17.0.2"}}}})) do |project|
+        File.read(project / "node_modules/react/index.js").should eq("17.0.2")
+      end
+    end
+  end
+
+  it "lets workspace members use different catalogs for the same name" do
+    It.with_registry do |registry|
+      registry.add("react", "17.0.2", It.pkg("react", "17.0.2"), {"index.js" => "17.0.2"})
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-ws-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":["packages/*"],"zap":{"catalog":{"react":"^18.3.1"},"catalogs":{"react17":{"react":"^17.0.2"}}}}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","dependencies":{"react":"catalog:"}}))
+        File.write(ws_root / "packages/b/package.json", %({"name":"b","version":"1.0.0","dependencies":{"react":"catalog:react17"}}))
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # Both versions are resolved, and each member is pinned to its own
+        # catalog's version regardless of which one the hoisting placed at
+        # the root.
+        lock = File.read(ws_root / "zap.lock")
+        lock.should contain("react@18.3.1")
+        lock.should contain("react@17.0.2")
+        lockfile = Data::Lockfile.new(ws_root)
+        lockfile.roots["a"].dependency_specifier?("react").to_s.should eq("18.3.1")
+        lockfile.roots["b"].dependency_specifier?("react").to_s.should eq("17.0.2")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "fails when the default catalog has no entry for the name" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      raised = false
+      begin
+        It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"lodash":"^4.0.0"}}})) { |_| }
+      rescue ex
+        raised = true
+        ex.message.not_nil!.should contain("no entry for react")
+      end
+      raised.should be_true
+    end
+  end
+
+  it "fails when the referenced catalog is not defined" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      raised = false
+      begin
+        It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:missing"},"zap":{"catalog":{"react":"^18.3.1"}}})) { |_| }
+      rescue ex
+        raised = true
+        ex.message.not_nil!.should contain("catalog")
+      end
+      raised.should be_true
+    end
+  end
+
+  it "fails when no catalog is defined" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      raised = false
+      begin
+        It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"}})) { |_| }
+      rescue ex
+        raised = true
+        ex.message.not_nil!.should contain("catalog")
+      end
+      raised.should be_true
+    end
+  end
+
+  it "supports the catalog reference in devDependencies" do
+    It.with_registry do |registry|
+      registry.add("dev-tool", "1.0.0", It.pkg("dev-tool", "1.0.0"), {"index.js" => "d"})
+
+      It.install_project(registry, %({"name":"app","version":"1.0.0","devDependencies":{"dev-tool":"catalog:"},"zap":{"catalog":{"dev-tool":"^1.0.0"}}})) do |project|
+        File.read(project / "node_modules/dev-tool/index.js").should eq("d")
+      end
+    end
+  end
+
+  it "pins the resolved version and honors it on reinstall" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "zap.lock").should contain("react@18.3.1")
+
+        # A plain reinstall keeps the pinned version
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(tmpdir / "node_modules/react/index.js").should eq("18.3.1")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "expands the catalog reference in peerDependencies" do
+    It.with_registry do |registry|
+      registry.add("react", "16.0.0", It.pkg("react", "16.0.0"), {"index.js" => "16.0.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-ws-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":["packages/*"],"dependencies":{"react":"16.0.0"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","peerDependencies":{"react":"catalog:"}}))
+        File.write(ws_root / "packages/b/package.json", %({"name":"b","version":"1.0.0","dependencies":{"a":"workspace:^1.0.0"}}))
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, check_peer_dependencies: true)
+        out_io = IO::Memory.new
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Plain.new(out_io))
+
+        # The catalog peer range (^18.3.1) is not satisfied by the root's
+        # react 16.0.0, so the peer is reported as unmet.
+        out_io.to_s.should contain("peer")
+        out_io.to_s.should contain("react")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "resolves an alias stored in a catalog entry" do
+    It.with_registry do |registry|
+      registry.add("real", "1.0.0", It.pkg("real", "1.0.0"), {"index.js" => "real"})
+
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"my-alias":"catalog:"},"zap":{"catalog":{"my-alias":"npm:real@^1.0.0"}}})) do |project|
+        File.read(project / "node_modules/my-alias/index.js").should eq("real")
+      end
+    end
+  end
+
+  it "resolves a catalog reference in overrides" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "2.0.0", It.pkg("dep", "2.0.0"), {"index.js" => "2.0.0"})
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "p"})
+
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"},"overrides":{"dep":"catalog:"},"zap":{"catalog":{"dep":"^2.0.0"}}})) do |project|
+        File.read(project / "node_modules/dep/index.js").should eq("2.0.0")
+      end
+    end
+  end
+
+  it "rewrites the specifier literally when updating a catalog dependency" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+      registry.add("react", "19.0.0", It.pkg("react", "19.0.0"), {"index.js" => "19.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # An explicit range update leaves the catalog and writes the literal
+        # specifier (documented divergence: the catalog entry itself is not
+        # edited).
+        targeted = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, updated_packages: ["react@^19.0.0"])
+        Commands::Install.run(config, targeted, raise_on_failure: true, reporter: Reporter::Null.new)
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["react"].as_s.should eq("^19.0.0")
+        File.read(tmpdir / "node_modules/react/index.js").should eq("19.0.0")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "fails a frozen install when the catalog entry changed" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+      registry.add("react", "19.0.0", It.pkg("react", "19.0.0"), {"index.js" => "19.0.0"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The catalog entry moves the dependency out of the pinned resolution
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^19.0.0"}}}))
+        expect_raises(Exception, /frozen-lockfile/) do
+          Commands::Install.run(config, ic.copy_with(frozen_lockfile: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        end
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+end

--- a/packages/data/package/fields/config.cr
+++ b/packages/data/package/fields/config.cr
@@ -31,7 +31,9 @@ class Data::Package
       block_exotic_subdeps : Bool? = nil,
       trust_policy : String? = nil,
       trust_policy_exclude : Array(String)? = nil,
-      named_registries : Hash(String, String)? = nil do
+      named_registries : Hash(String, String)? = nil,
+      catalog : Hash(String, String)? = nil,
+      catalogs : Hash(String, Hash(String, String))? = nil do
       include JSON::Serializable
       include YAML::Serializable
       include MessagePack::Serializable

--- a/specifications/README.md
+++ b/specifications/README.md
@@ -44,6 +44,7 @@ A readable example, rendered exactly like the real specs:
 - [Security](security.md) — the supply-chain guards.
 - [Workspaces](workspaces.md) — monorepo support.
 - [Configuration](config.md) — the `zap` section and the npmrc.
+- [Catalogs](catalogs.md) — the `catalog:` protocol (pnpm / yarn parity).
 
 ## The process: specification-first development
 

--- a/specifications/catalogs.md
+++ b/specifications/catalogs.md
@@ -1,0 +1,63 @@
+# Catalogs
+
+The `catalog:` protocol: dependency version ranges defined once at the
+workspace root and referenced from the manifests by name. Parity target: pnpm
+`catalog:` / `catalog:<name>` and yarn berry's catalogs.
+
+- **Resolve the reference to its range.** A specifier `catalog:` resolves to
+  the entry for the dependency name in the default catalog (`zap.catalog`);
+  `catalog:<name>` resolves to the entry in the named catalog
+  (`zap.catalogs.<name>`). The expansion happens before any protocol
+  dispatch, so the value behaves like a regular specifier (a range, an
+  alias, or a named-registry prefix).
+  - [packages/commands/install/resolver.cr](../packages/commands/install/resolver.cr)
+    the expansion at the top of `Resolver.resolve`
+  - [packages/data/package/fields/config.cr](../packages/data/package/fields/config.cr)
+    `ZapConfig#catalog`, `ZapConfig#catalogs`
+
+  ```text
+  expand_catalog(name, specifier):
+      catalog_name = specifier == "catalog:" ? "default" : specifier after "catalog:"
+      entries = catalog_name == "default" ? zap.catalog : zap.catalogs[catalog_name]
+      if no entries: fail("the catalog is not defined")
+      return entries[name] or fail("the catalog has no entry for name")
+  ```
+
+- **Fail with a clear error when the catalog or the entry is missing**,
+  naming the dependency and the catalog.
+
+- **Apply the expansion to every manifest field** (`dependencies`,
+  `devDependencies`, `optionalDependencies`, `peerDependencies`) and to the
+  `overrides`, since they all flow through the same resolution entry point.
+
+- **Keep the lockfile honest.** The resolved version is pinned as usual; an
+  edit to a catalog entry changes the resolution and fails a frozen install
+  through the normal drift check. The lockfile stores the expanded range.
+
+- **Diverge deliberately, documented:** the catalogs live in the `zap`
+  section of the root `package.json` (not `pnpm-workspace.yaml` or
+  `.yarnrc.yml`); the lockfile records the expanded range rather than the
+  `catalog:` reference; `zap up pkg@range` rewrites the specifier literally
+  instead of editing the catalog entry; the interactive update list does not
+  include catalog dependencies (their specifier is not a semver range); there
+  is no `catalogMode` (the `zap add` catalog behavior), and catalog references
+  are written in the manifest by hand.
+
+## Reference
+
+```json
+{
+  "zap": {
+    "catalog": { "react": "^18.3.1", "lodash": "^4.17.21" },
+    "catalogs": {
+      "react17": { "react": "^17.0.2" }
+    }
+  }
+}
+```
+
+```json
+{ "dependencies": { "react": "catalog:", "lodash": "catalog:", "old-react": "catalog:react17" } }
+```
+
+`catalog:` is the shorthand for `catalog:default`.


### PR DESCRIPTION
Support the `catalog:` protocol (issue #30), pnpm / yarn parity.

## What's here

- `zap.catalog` (the default catalog) and `zap.catalogs` (named catalogs) in the root `package.json`, mirroring pnpm's `catalog` / `catalogs` and yarn's `.yarnrc.yml` catalogs.
- A `"catalog:"` dependency specifier resolves to the default catalog's entry for the name; `"catalog:<name>"` to the named catalog's. The reference is expanded to the catalog range before the protocol dispatch, so it behaves like a regular specifier (ranges, aliases, named-registry prefixes all work).
- The expansion applies to `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, and `overrides` (the peer ranges are expanded at the linker's peer-resolution sites).
- The resolved version is pinned as usual: a catalog edit changes the resolution and fails frozen installs through the normal drift check.

## Documented divergences

- The catalogs live in the `zap` section of the root `package.json` (not `pnpm-workspace.yaml` / `.yarnrc.yml`).
- The lockfile stores the expanded range, not the `catalog:` reference.
- `zap up pkg@range` writes the literal range instead of editing the catalog entry (and the `catalog:` prefix is excluded from the named-registry alias-preserving rewrite, which previously would have mangled it).
- No `catalogMode`; catalog references are written in the manifest by hand.

## Verification

- `specifications/catalogs.md` — the specification (behavior, file links, pseudo-code, divergences).
- 13 ported specs: default + named resolution, per-member catalogs in a workspace, missing-entry / unknown-catalog / no-catalog errors, devDependencies, peers (a catalog peer range is enforced against the provider), overrides, aliases, the lockfile pin, the literal update rewrite, and the frozen-install drift on a catalog edit.
- 355 commands specs, 927+ across all 8 packages, 0 failures.
