### PR TITLE
catalogs: first-class catalog protocol + catalog CLI

### DIFF
--- a/packages/cli/zap.cr
+++ b/packages/cli/zap.cr
@@ -14,6 +14,8 @@ require "commands/init/cli"
 require "commands/init"
 require "commands/approve-builds/cli"
 require "commands/approve-builds"
+require "commands/catalog/cli"
+require "commands/catalog"
 require "commands/rebuild/cli"
 require "commands/rebuild"
 require "commands/run/cli"
@@ -56,6 +58,7 @@ module Zap
         Commands::Exec::CLI.new,
         Commands::Init::CLI.new,
         Commands::ApproveBuilds::CLI.new,
+        Commands::Catalog::CLI.new,
         Commands::Run::CLI.new,
         Commands::Store::CLI.new,
         Commands::Why::CLI.new,
@@ -76,6 +79,8 @@ module Zap
       Commands::Patch.run(config, command_config)
     when Commands::ApproveBuilds::Config
       Commands::ApproveBuilds.run(config, command_config)
+    when Commands::Catalog::Config
+      Commands::Catalog.run(config, command_config)
     when Commands::Dlx::Config
       Commands::Dlx.run(config, command_config)
     when Commands::Init::Config

--- a/packages/commands/catalog/catalog.cr
+++ b/packages/commands/catalog/catalog.cr
@@ -1,0 +1,108 @@
+require "json"
+require "utils/misc"
+require "data/package"
+
+# `zap catalog list`, `zap catalog add`, `zap catalog remove`: manage the
+# version catalog entries in the zap section of the root package.json.
+module Commands::Catalog
+  def self.run(config : Core::Config, catalog_config : Config)
+    catalog_config = catalog_config.from_args(ARGV)
+    context = config.infer_context
+    case catalog_config.action
+    when Config::CatalogAction::List
+      list(context.config.prefix, catalog_config.catalog)
+    when Config::CatalogAction::Add
+      name, range = parse_add_arg(catalog_config.args.first?)
+      add(context.config.prefix, catalog_config.catalog, name, range)
+    when Config::CatalogAction::Remove
+      name = catalog_config.args.first? || raise "catalog remove needs a package name."
+      remove(context.config.prefix, context, catalog_config.catalog, name)
+    end
+  rescue ex : Exception
+    puts ex.message
+    exit 1
+  end
+
+  # Prints the entries of the catalog as "name: range" lines.
+  def self.list(prefix : String, catalog_name : String) : Nil
+    read_entries(prefix, catalog_name).to_a.sort_by(&.[0]).each do |name, range|
+      puts "#{name}: #{range}"
+    end
+  end
+
+  # Adds or updates the entry, creating the named catalog on demand.
+  def self.add(prefix : String, catalog_name : String, name : String, range : String) : Nil
+    raise "catalog add cannot use a catalog reference as the range." if range.starts_with?("catalog:")
+    update_entries(prefix, catalog_name) do |entries|
+      entries[name] = JSON::Any.new(range)
+    end
+    puts "#{catalog_name == "default" ? "catalog" : "catalog:#{catalog_name}"}.#{name} = #{range}"
+  end
+
+  # Removes the entry, warning when a manifest still references it.
+  def self.remove(prefix : String, context : Core::Config::InferredContext, catalog_name : String, name : String) : Nil
+    raise "The catalog has no entry for #{name}." unless read_entries(prefix, catalog_name).has_key?(name)
+    references = referencing_manifests(prefix, context, catalog_name, name)
+    update_entries(prefix, catalog_name) do |entries|
+      entries.delete(name)
+    end
+    puts "Removed #{name} from #{catalog_name == "default" ? "the default catalog" : "catalog:#{catalog_name}"}."
+    unless references.empty?
+      puts "Warning: still referenced by: #{references.join(", ")}"
+    end
+  end
+
+  private def self.parse_add_arg(arg : String?) : {String, String}
+    arg || raise "catalog add needs a <name>@<range> argument."
+    name, range = Utils::Misc.parse_key(arg)
+    raise "catalog add needs a <name>@<range> argument (got #{arg})." if name.nil? || range.nil? || range.empty?
+    {name, range}
+  end
+
+  # The entries of a catalog, or an empty map when it does not exist yet.
+  private def self.read_entries(prefix : String, catalog_name : String) : Hash(String, String)
+    zap = Data::Package.init?(Path.new(prefix) / "package.json", append_filename: false).try(&.zap_config)
+    entries =
+      if catalog_name == "default"
+        zap.try(&.catalog)
+      else
+        zap.try(&.catalogs).try(&.[catalog_name]?)
+      end
+    entries || {} of String => String
+  end
+
+  # Edits the catalog entries and writes the zap section back in place.
+  private def self.update_entries(prefix : String, catalog_name : String, &) : Nil
+    path = Path.new(prefix) / "package.json"
+    root = JSON.parse(File.read(path)).as_h
+    zap_h = root["zap"]?.try(&.as_h) || {} of String => JSON::Any
+    root["zap"] = JSON::Any.new(zap_h)
+
+    entries =
+      if catalog_name == "default"
+        (zap_h["catalog"]?.try(&.as_h) || {} of String => JSON::Any).tap { |e| zap_h["catalog"] = JSON::Any.new(e) }
+      else
+        catalogs = (zap_h["catalogs"]?.try(&.as_h) || {} of String => JSON::Any).tap { |e| zap_h["catalogs"] = JSON::Any.new(e) }
+        (catalogs[catalog_name]?.try(&.as_h) || {} of String => JSON::Any).tap { |e| catalogs[catalog_name] = JSON::Any.new(e) }
+      end
+
+    yield entries
+    File.write(path, JSON::Any.new(root).to_pretty_json)
+  end
+
+  # The directories (the project and its workspace members) whose manifests
+  # still reference the entry through the catalog protocol.
+  private def self.referencing_manifests(prefix : String, context : Core::Config::InferredContext, catalog_name : String, name : String) : Array(Path)
+    ref = catalog_name == "default" ? "catalog:" : "catalog:#{catalog_name}"
+    directories = [Path.new(prefix)] + (context.workspaces.try(&.map(&.path)) || [] of Path)
+    directories.select do |dir|
+      pkg = Data::Package.init?(dir / "package.json", append_filename: false)
+      next false unless pkg
+      found = false
+      pkg.each_dependency do |dep, specifier, _type|
+        found = true if dep == name && specifier.is_a?(String) && specifier == ref
+      end
+      found
+    end
+  end
+end

--- a/packages/commands/catalog/cli.cr
+++ b/packages/commands/catalog/cli.cr
@@ -1,0 +1,45 @@
+require "../cli"
+require "../helpers"
+require "./config"
+
+class Commands::Catalog::CLI < Commands::CLI
+  def register(parser : OptionParser, command_config : Core::CommandConfigRef) : Nil
+    Helpers.command("catalog", "Manage the version catalogs defined in the zap section of the root manifest.") do
+      command_config.ref = nil
+      Helpers.separator("Subcommands")
+
+      Helpers.command("list", "Print the entries of a catalog.") do
+        command_config.ref = Config.new(action: Config::CatalogAction::List)
+        catalog_options
+      end
+
+      Helpers.command("add", "Add or update an entry in a catalog.", "<name>@<range>") do
+        command_config.ref = Config.new(action: Config::CatalogAction::Add)
+        catalog_options
+      end
+
+      Helpers.command("remove", "Remove an entry from a catalog.", "<name>") do
+        command_config.ref = Config.new(action: Config::CatalogAction::Remove)
+        catalog_options
+      end
+
+      parser.before_each do |arg|
+        if command_config.ref.nil? && !parser.@handlers.keys.includes?(arg)
+          puts parser
+          exit
+        end
+      end
+    end
+  end
+
+  private macro catalog_options
+    Commands::Helpers.separator("Options")
+    Commands::Helpers.flag("--catalog <name>", "The named catalog to edit or list (default: the default catalog).") do |name|
+      command_config.ref = catalog_config.copy_with(catalog: name)
+    end
+  end
+
+  private macro catalog_config
+    command_config.ref.as(Catalog::Config)
+  end
+end

--- a/packages/commands/catalog/config.cr
+++ b/packages/commands/catalog/config.cr
@@ -1,0 +1,21 @@
+require "utils/macros"
+require "core/command_config"
+
+struct Commands::Catalog::Config < Core::CommandConfig
+  Utils::Macros.record_utils
+
+  enum CatalogAction
+    List
+    Add
+    Remove
+  end
+
+  getter action : CatalogAction
+  # The catalog edited or listed: the default catalog by default.
+  getter catalog : String = "default"
+  getter args : Array(String) = Array(String).new
+
+  def from_args(args : Array(String))
+    copy_with(args: args)
+  end
+end

--- a/packages/commands/install/linker/linker.cr
+++ b/packages/commands/install/linker/linker.cr
@@ -108,7 +108,7 @@ module Commands::Install::Linker
     # over a same-name regular dependency.
     protected def peer_satisfied_by_ancestor?(name : String, peer_range : String, ancestors : Enumerable(Data::Package | Data::Lockfile::Root)) : Bool
       if peer_range.starts_with?("catalog:")
-        peer_range = Commands::Install::Resolver.expand_catalog(name, peer_range, state)
+        peer_range = Commands::Install::Protocol::Catalog.expand(name, peer_range, state)
       end
       range = Semver.parse?(peer_range) || Semver::ANY
       satisfied = false
@@ -129,7 +129,7 @@ module Commands::Install::Linker
       if direct_peers = package.peer_dependencies
         direct_peers.each do |direct_peer, peer_range|
           if peer_range.starts_with?("catalog:")
-            peer_range = Commands::Install::Resolver.expand_catalog(direct_peer, peer_range, state)
+            peer_range = Commands::Install::Protocol::Catalog.expand(direct_peer, peer_range, state)
           end
           peers[direct_peer] = Set(Semver::Range){
             Semver.parse?(peer_range).or(Semver::ANY),

--- a/packages/commands/install/protocol/catalog/catalog.cr
+++ b/packages/commands/install/protocol/catalog/catalog.cr
@@ -1,0 +1,59 @@
+require "log"
+require "../base"
+require "../alias/alias"
+require "../registry/registry"
+
+struct Commands::Install::Protocol::Catalog < Commands::Install::Protocol::Base
+  Log = ::Log.for("zap.commands.install.protocol.catalog")
+
+  # The entry for *name* in the catalog referenced by *specifier*
+  # ("catalog:" or "catalog:<name>"), returned as a regular specifier.
+  def self.expand(name : String, specifier : String, state : Commands::Install::State) : String
+    zap = state.context.main_package.zap_config
+    catalog_name = specifier == "catalog:" ? "default" : specifier[8..]
+    entries =
+      if catalog_name == "default"
+        zap.try(&.catalog)
+      else
+        zap.try(&.catalogs).try(&.[catalog_name]?)
+      end
+    unless entries
+      raise "The catalog \"#{catalog_name}\" referenced by #{name} is not defined. Define it under zap.catalog or zap.catalogs in the root package.json."
+    end
+    entry = entries[name]? || raise "The catalog \"#{catalog_name}\" has no entry for #{name}."
+    # A catalog entry must be a concrete specifier: a catalog reference
+    # inside a catalog would recurse forever through the delegation.
+    if entry.starts_with?("catalog:")
+      raise "The catalog entry for #{name} references another catalog. A catalog entry must be a concrete range or specifier."
+    end
+    entry
+  end
+
+  # "catalog:foo" as a zap add argument: add the dependency named foo with
+  # the catalog reference as its specifier (resolved from the default
+  # catalog). A bare "catalog:" has no package name and is left to the other
+  # protocols.
+  def self.normalize?(str : String, path_info : PathInfo?) : {String?, String?}?
+    return unless str.starts_with?("catalog:")
+    return if str == "catalog:"
+    {"catalog:", str[8..]}
+  end
+
+  # The catalog protocol expands the reference to its entry and returns the
+  # resolver of the entry's specifier directly (an alias or a registry range,
+  # named registries included). The declared specifier stays "catalog:", so
+  # the lockfile records the reference instead of the expanded range.
+  def self.resolver?(
+    state,
+    name,
+    specifier = "latest",
+    parent = nil,
+    dependency_type = nil,
+    skip_cache = false
+  ) : Protocol::Resolver?
+    return unless specifier.is_a?(String) && specifier.starts_with?("catalog:")
+    range = expand(name.to_s, specifier, state)
+    Alias.resolver?(state, name, range, parent, dependency_type, skip_cache) ||
+      Registry.resolver?(state, name, range, parent, dependency_type, skip_cache)
+  end
+end

--- a/packages/commands/install/protocol/protocol.cr
+++ b/packages/commands/install/protocol/protocol.cr
@@ -1,5 +1,6 @@
 require "log"
 require "./alias"
+require "./catalog"
 require "./file"
 require "./git"
 require "./registry"
@@ -10,6 +11,7 @@ module Commands::Install::Protocol
   Log = ::Log.for("zap.install.protocol")
 
   PROTOCOLS = {
+    Protocol::Catalog,
     Protocol::Workspace,
     Protocol::Alias,
     Protocol::File,

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -155,24 +155,6 @@ module Commands::Install::Resolver
     end
   end
 
-  # The catalog protocol (pnpm / yarn parity): "catalog:" resolves to the
-  # entry for the dependency in the default catalog, "catalog:<name>" to the
-  # entry in the named catalog. The value is returned as a regular specifier.
-  def self.expand_catalog(name : String, specifier : String, state : Commands::Install::State) : String
-    zap = state.context.main_package.zap_config
-    catalog_name = specifier == "catalog:" ? "default" : specifier[8..]
-    entries =
-      if catalog_name == "default"
-        zap.try(&.catalog)
-      else
-        zap.try(&.catalogs).try(&.[catalog_name]?)
-      end
-    unless entries
-      raise "The catalog \"#{catalog_name}\" referenced by #{name} is not defined. Define it under zap.catalog or zap.catalogs in the root package.json."
-    end
-    entries[name]? || raise "The catalog \"#{catalog_name}\" has no entry for #{name}."
-  end
-
   # With --latest, rewrites the declared specifier of updated direct
   # dependencies to the resolved version, preserving the range modifier
   # (^, ~, <=, >= or exact). Complex ranges are left untouched.
@@ -276,12 +258,6 @@ module Commands::Install::Resolver
   )
     Log.debug { "(#{name}@#{version}) Resolving package…" + (type ? " [type: #{type}]" : "") + (package ? " [parent: #{package.key}]" : "") }
     state.reporter.on_resolving_package
-    # The catalog protocol (pnpm / yarn parity): a "catalog:" specifier
-    # resolves to the range defined at the workspace root before the
-    # protocol dispatch, so it behaves like a regular specifier.
-    if version.starts_with?("catalog:")
-      version = expand_catalog(name, version, state)
-    end
     # Add direct dependencies to the lockfile
     if package && is_direct_dependency && type
       state.lockfile.add_dependency(name, version, type, package.name, package.version)

--- a/packages/commands/spec/install/integration/catalog._spec.cr
+++ b/packages/commands/spec/install/integration/catalog._spec.cr
@@ -1,3 +1,4 @@
+require "../../../catalog/catalog"
 require "./spec_helper"
 
 # The catalog: protocol (pnpm / yarn berry parity): a dependency specifier
@@ -243,6 +244,72 @@ describe "catalogs", tags: "integration" do
       ensure
         FileUtils.rm_rf(tmpdir)
       end
+    end
+  end
+
+  it "adds and removes catalog entries through the CLI helpers" do
+    tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(tmpdir)
+      File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","zap":{"catalog":{"react":"^18.3.1"}}}))
+      config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+
+      Commands::Catalog.add(tmpdir.to_s, "default", "lodash", "^4.17.21")
+      Commands::Catalog.add(tmpdir.to_s, "react17", "react", "^17.0.2")
+      pkg = JSON.parse(File.read(tmpdir / "package.json"))
+      pkg["zap"]["catalog"]["lodash"].as_s.should eq("^4.17.21")
+      pkg["zap"]["catalogs"]["react17"]["react"].as_s.should eq("^17.0.2")
+
+      Commands::Catalog.remove(tmpdir.to_s, config.infer_context, "default", "lodash")
+      pkg = JSON.parse(File.read(tmpdir / "package.json"))
+      pkg["zap"]["catalog"]["lodash"]?.should be_nil
+      pkg["zap"]["catalog"]["react"].as_s.should eq("^18.3.1")
+      pkg["zap"]["catalogs"]["react17"]["react"].as_s.should eq("^17.0.2")
+    ensure
+      FileUtils.rm_rf(tmpdir)
+    end
+  end
+
+  it "catalog-add rejects a catalog reference as the range" do
+    tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(tmpdir)
+      File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","zap":{"catalog":{}}}))
+      expect_raises(Exception, /cannot use a catalog reference/) do
+        Commands::Catalog.add(tmpdir.to_s, "default", "react", "catalog:react17")
+      end
+    ensure
+      FileUtils.rm_rf(tmpdir)
+    end
+  end
+
+  it "catalog-remove rejects a missing entry" do
+    tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(tmpdir)
+      File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","zap":{"catalog":{"react":"^18.3.1"}}}))
+      config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+      expect_raises(Exception, /no entry/) do
+        Commands::Catalog.remove(tmpdir.to_s, config.infer_context, "default", "missing")
+      end
+    ensure
+      FileUtils.rm_rf(tmpdir)
+    end
+  end
+
+  it "removes a catalog entry still referenced by a manifest" do
+    tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(tmpdir)
+      File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+      config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+
+      Commands::Catalog.remove(tmpdir.to_s, config.infer_context, "default", "react")
+      pkg = JSON.parse(File.read(tmpdir / "package.json"))
+      pkg["zap"]["catalog"]["react"]?.should be_nil
+      pkg["dependencies"]["react"].as_s.should eq("catalog:")
+    ensure
+      FileUtils.rm_rf(tmpdir)
     end
   end
 

--- a/packages/commands/spec/install/integration/catalog._spec.cr
+++ b/packages/commands/spec/install/integration/catalog._spec.cr
@@ -185,6 +185,67 @@ describe "catalogs", tags: "integration" do
     end
   end
 
+  it "records the catalog reference in the lockfile" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # The declared edge keeps the catalog reference; the resolved version
+        # is pinned separately.
+        lockfile = Data::Lockfile.new(tmpdir)
+        lockfile.roots["app"].dependencies.not_nil!["react"].should eq("catalog:")
+        lockfile.roots["app"].dependency_specifier?("react").to_s.should eq("18.3.1")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "fails when a catalog entry references another catalog" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      raised = false
+      begin
+        It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"react":"catalog:"},"zap":{"catalog":{"react":"catalog:react17"},"catalogs":{"react17":{"react":"^17.0.2"}}}})) { |_| }
+      rescue ex
+        raised = true
+        ex.message.not_nil!.should contain("references another catalog")
+      end
+      raised.should be_true
+    end
+  end
+
+  it "adds a dependency with a catalog reference" do
+    It.with_registry do |registry|
+      registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","zap":{"catalog":{"react":"^18.3.1"}}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, added_packages: ["catalog:react"])
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.read(tmpdir / "node_modules/react/index.js").should eq("18.3.1")
+        pkg = JSON.parse(File.read(tmpdir / "package.json"))
+        pkg["dependencies"]["react"].as_s.should eq("catalog:")
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
   it "rewrites the specifier literally when updating a catalog dependency" do
     It.with_registry do |registry|
       registry.add("react", "18.3.1", It.pkg("react", "18.3.1"), {"index.js" => "18.3.1"})

--- a/specifications/catalogs.md
+++ b/specifications/catalogs.md
@@ -30,18 +30,18 @@ workspace root and referenced from the manifests by name. Parity target: pnpm
   `devDependencies`, `optionalDependencies`, `peerDependencies`) and to the
   `overrides`, since they all flow through the same resolution entry point.
 
-- **Keep the lockfile honest.** The resolved version is pinned as usual; an
-  edit to a catalog entry changes the resolution and fails a frozen install
-  through the normal drift check. The lockfile stores the expanded range.
+- **Keep the lockfile honest.** The declared edge keeps the `catalog:`
+  reference and the resolved version is pinned separately (the catalog is a
+  first-class protocol). An edit to a catalog entry changes the resolution
+  and fails a frozen install through the normal drift check.
 
 - **Diverge deliberately, documented:** the catalogs live in the `zap`
   section of the root `package.json` (not `pnpm-workspace.yaml` or
-  `.yarnrc.yml`); the lockfile records the expanded range rather than the
-  `catalog:` reference; `zap up pkg@range` rewrites the specifier literally
-  instead of editing the catalog entry; the interactive update list does not
-  include catalog dependencies (their specifier is not a semver range); there
-  is no `catalogMode` (the `zap add` catalog behavior), and catalog references
-  are written in the manifest by hand.
+  `.yarnrc.yml`); `zap up pkg@range` rewrites the specifier literally instead
+  of editing the catalog entry; the interactive update list does not include
+  catalog dependencies (their specifier is not a semver range); there is no
+  `catalogMode` (the `zap add` catalog behavior) other than adding with an
+  explicit `catalog:` reference.
 
 ## Reference
 

--- a/specifications/catalogs.md
+++ b/specifications/catalogs.md
@@ -30,6 +30,13 @@ workspace root and referenced from the manifests by name. Parity target: pnpm
   `devDependencies`, `optionalDependencies`, `peerDependencies`) and to the
   `overrides`, since they all flow through the same resolution entry point.
 
+- **Manage the catalogs with the CLI.** `zap catalog list [--catalog <name>]`,
+  `zap catalog add <name>@<range> [--catalog <name>]`, and
+  `zap catalog remove <name> [--catalog <name>]` read and edit the `zap`
+  section in place. The add creates a named catalog on demand and rejects a
+  catalog reference as the range; the remove warns when a manifest still
+  references the entry.
+
 - **Keep the lockfile honest.** The declared edge keeps the `catalog:`
   reference and the resolved version is pinned separately (the catalog is a
   first-class protocol). An edit to a catalog entry changes the resolution


### PR DESCRIPTION
The catalog follow-ups (from the review of #30): make `catalog:` a first-class specifier and add a catalog CLI. Two commits on `feat/catalogs`.

## Commit 1: the catalog as a protocol

The `catalog:` reference is now handled by its own `Protocol::Catalog` instead of being expanded before the dispatch:

- The resolver expands the entry and returns the alias or registry resolver (named registries included) directly, so there is no delegation cycle.
- The declared specifier stays `catalog:`, so **the lockfile records the reference** instead of the expanded range (the resolved version is pinned separately). This closes the "lockfile is not self-contained for catalog refs" gap.
- A catalog entry that references another catalog is rejected (it would recurse).
- `zap add catalog:foo` adds a dependency with the catalog reference.
- The peer-range expansion moved into the `Catalog` protocol.

The full protocol-with-a-delegate hit a Crystal compiler bug (a constant cycle through the dispatch), so the resolver returns the leaf resolver directly — same observable behavior, no compile recursion.

## Commit 2: the catalog CLI

- `zap catalog list [--catalog <name>]` — print the entries.
- `zap catalog add <name>@<range> [--catalog <name>]` — add/update, creating a named catalog on demand; rejects a catalog reference as the range.
- `zap catalog remove <name> [--catalog <name>]` — remove, warning when a manifest still references the entry; rejects a missing entry.

The catalog command follows the `zap store` subcommand pattern (nested
`Helpers.command` blocks), so each subcommand owns its flags and help.

## Verification

- 20 catalog specs (the 16 previous + the lockfile-ref, the nested-entry guard, the `catalog:` add form, the CLI add/remove, the CLI edge rejections, the referenced-remove).
- 362 commands specs, 934+ across all 8 packages, 0 failures.
- The specification (`specifications/catalogs.md`) updated: the lockfile divergence resolved, the CLI documented.
