### PR TITLE
feat: prefer-dedupe — collapse compatible resolutions into the highest version in use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,9 +135,14 @@ jobs:
         if: ${{ env.needs_release == 1 }}
         with:
           script: |
-            const { version } = require("./npm/zap/package.json")
+            const fs = require("fs")
+            const shard = fs.readFileSync("shard.yml", "utf8")
+            const match = shard.match(/^version:\s*(\S+)/m)
+            if (!match) throw new Error("version missing from shard.yml")
+            const version = match[1]
             const semverRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-            const [, major, minor, patch, prerelease, metadata] = version.match(semverRegex)
+            const [, major, minor, patch, prerelease, metadata] = version.match(semverRegex) || []
+            if (!major) throw new Error(`invalid shard.yml version: ${version}`)
             const data = {
               version,
               major,
@@ -147,10 +152,9 @@ jobs:
               metadata,
               distTag: prerelease ? prerelease.split(".")[0] : "latest"
             }
-
             console.log(data)
-
             return data
+
       - name: Trigger release
         if: ${{ env.needs_release == 1 }}
         env:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ zap --help
 | `zap why`     | `y`                   | Show information about why a package is installed      | ✅       |
 | `zap patch`   |                       | Extract a package for editing, to be patched           | ✅       |
 | `zap patch-commit` |                 | Generate and register a patch from an edited package   | ✅       |
+| `zap dedupe`       |                 | Collapse compatible duplicate versions into the highest in use | ✅ |
 
 #### Check the [project board](https://github.com/users/elbywan/projects/1/views/1) for the current status of the project.
 

--- a/packages/commands/install/cli.cr
+++ b/packages/commands/install/cli.cr
@@ -18,6 +18,10 @@ class Commands::Install::CLI < Commands::CLI
     Helpers.command(["update", "up", "upgrade"], "Update the lockfile to use the newest package versions.", "[options] <package(s)>") do
       on_install(parser, command_config, update_packages: true)
     end
+
+    Helpers.command(["dedupe"], "Collapse compatible duplicate package versions into the highest version in use.", "[options]") do
+      on_install(parser, command_config, dedupe: true)
+    end
   end
 
   def on_install(
@@ -26,8 +30,9 @@ class Commands::Install::CLI < Commands::CLI
     *,
     update_packages : Bool = false,
     remove_packages : Bool = false,
+    dedupe : Bool = false,
   ) : Nil
-    command_config.ref = Config.new(ENV, "ZAP_INSTALL").copy_with(update_all: update_packages)
+    command_config.ref = Config.new(ENV, "ZAP_INSTALL").copy_with(update_all: update_packages || dedupe, update_recursive: dedupe, dedupe: dedupe, force_metadata_retrieval: dedupe)
 
     Helpers.separator("Options")
 

--- a/packages/commands/install/config.cr
+++ b/packages/commands/install/config.cr
@@ -69,6 +69,14 @@ struct Commands::Install::Config < Core::CommandConfig
   getter engine_strict : Bool = false
   @[Env]
   getter prefer_offline : Bool = false
+  # prefer-dedupe: reuse the highest already-used version that satisfies
+  # the declared range instead of resolving a fresh one (pnpm parity).
+  @[Env]
+  getter prefer_dedupe : Bool? = nil
+  # One-shot deduplication (`zap dedupe`): re-resolve the whole tree with
+  # the prefer-dedupe preference to collapse compatible versions already
+  # pinned in the lockfile. Command-only, no env var.
+  getter dedupe : Bool = false
   # Single-threaded by default: fetches run in the caller's fiber, so extra
   # pipeline threads only add overhead (measured ~30% slower cold installs).
   # Bump with --workers / ZAP_WORKERS when more parallelism pays off.

--- a/packages/commands/install/install.cr
+++ b/packages/commands/install/install.cr
@@ -423,14 +423,14 @@ module Commands::Install
         next if overrides.try(&.has_key?(dep_name))
         next unless declared.is_a?(String)
         next unless range = Semver.parse?(declared)
-        resolved =
-          if type.optional_dependency?
-            pkg.optional_dependencies_refs.find { |ref| ref.name == dep_name }
-          else
-            pkg.dependencies_refs.find { |ref| ref.name == dep_name }
-          end
+        refs = type.optional_dependency? ? pkg.optional_dependencies_refs : pkg.dependencies_refs
+        # An aliased dependency resolves to the same real package, so its ref
+        # (which carries the real name) can precede the direct dependency's
+        # ref. The lockfile is only inconsistent when no ref for the name
+        # satisfies the declared range.
+        next if refs.any? { |ref| ref.name == dep_name && range.satisfies?(ref.version) }
+        resolved = refs.find { |ref| ref.name == dep_name }
         next unless resolved
-        next if range.satisfies?(resolved.version)
         errors << "#{pkg.key} resolves #{dep_name} to #{resolved.key}, which does not satisfy the declared range #{declared}"
       end
     end
@@ -574,9 +574,11 @@ module Commands::Install
                end
       Log.debug { "• Pruning previous install" }
       linker.remove(pruned_direct_dependencies)
-      linker.prune_orphan_modules
-      Log.debug { "• Installing packages" }
       linker.install
+      # The classic writer removes stale nested copies as it re-derives
+      # each package's placement; this walk only clears the top-level
+      # orphans whose key left the lockfile.
+      linker.prune_orphan_modules
       linker
     end
   end

--- a/packages/commands/install/linker/classic/writer/registry.cr
+++ b/packages/commands/install/linker/classic/writer/registry.cr
@@ -7,6 +7,7 @@ class Commands::Install::Linker::Classic
         return self
       end
 
+      parent_location = location
       hoist_location = location
       while !hoist_location.nil?
         location = hoist_location.parent.as(LocationNode?)
@@ -14,11 +15,43 @@ class Commands::Install::Linker::Classic
         return update_location(hoist_location) if location.nil?
         case action = hoisting_action?(location)
         in .no_install?
+          # The dependency is already satisfied at or above this level:
+          # any copy left at the direct parent's own node_modules is
+          # obsolete (the placement moved, e.g. a sibling subtree now
+          # provides the version at a higher level).
+          remove_stale_copy(parent_location)
           return
         in .stop?
           return update_location(hoist_location)
         in .continue?
+          # The hoist moved above the direct parent's level: a stale copy
+          # may still be present at the parent's own node_modules from a
+          # previous tree. The writer knows the new placement, so it can
+          # drop the obsolete copy without crawling the tree.
+          remove_stale_copy(parent_location) if hoist_location != parent_location
           hoist_location = location
+        end
+      end
+    end
+
+    # Removes the physical copy of this dependency at the direct parent's
+    # node_modules: it is only valid while the dependency is installed at
+    # the parent's own level, and the hoist above just decided otherwise.
+    private def remove_stale_copy(parent_location : LocationNode)
+      stale_path = parent_location.value.node_modules / (aliased_name || dependency.name)
+      return unless Dir.exists?(stale_path)
+      package = Data::Package.init?(stale_path)
+      if package
+        linker.unlink_binaries(package, stale_path)
+        state.reporter.on_package_removed("#{aliased_name || dependency.name}@#{package.version}")
+      end
+      FileUtils.rm_rf(stale_path)
+      state.installed_state.delete(stale_path.to_s)
+      # Drop the now-empty parent node_modules (except the root's).
+      unless parent_location.value.root
+        modules_dir = stale_path.parent
+        if Dir.exists?(modules_dir) && Dir.children(modules_dir).size < 1
+          FileUtils.rm_rf(modules_dir)
         end
       end
     end

--- a/packages/commands/install/linker/linker.cr
+++ b/packages/commands/install/linker/linker.cr
@@ -37,7 +37,10 @@ module Commands::Install::Linker
       end
     end
 
-    # Prune unused dependencies from the filesystem
+    # Prune unused dependencies from the filesystem. The classic linker's
+    # writer already removes stale nested copies as it re-derives each
+    # package's placement; this walk only clears the top-level orphans
+    # whose key left the lockfile.
     def prune_orphan_modules
       prune_workspace_orphans(Path.new(state.config.node_modules))
       state.context.workspaces.try &.each do |workspace|
@@ -47,6 +50,7 @@ module Commands::Install::Linker
 
     private def prune_workspace_orphans(modules_directory : Path, *, unlink_binaries : Bool = true)
       if Dir.exists?(modules_directory)
+        remaining = 0
         # For each hoisted or direct dependency
         Dir.each_child(modules_directory) do |package_dir|
           package_path = modules_directory / package_dir
@@ -54,6 +58,7 @@ module Commands::Install::Linker
           if package_dir.starts_with?('@')
             # Scoped package - recurse on children
             prune_workspace_orphans(package_path, unlink_binaries: unlink_binaries)
+            remaining += 1 if Dir.exists?(package_path)
           else
             if should_prune_orphan?(package_path)
               Log.debug { "Pruning orphan package: #{package_dir}" }
@@ -65,12 +70,15 @@ module Commands::Install::Linker
               end
               FileUtils.rm_rf(package_path)
               state.installed_state.delete(package_path.to_s)
+            else
+              remaining += 1
             end
           end
         end
 
-        # Remove modules directory if empty
-        if (size = Dir.children(modules_directory).size) < 1
+        # Remove modules directory if empty (the walk counted the remaining
+        # children, so no second enumeration is needed)
+        if remaining < 1
           FileUtils.rm_rf(modules_directory)
         end
       end

--- a/packages/commands/install/protocol/git/git.cr
+++ b/packages/commands/install/protocol/git/git.cr
@@ -49,6 +49,13 @@ struct Commands::Install::Protocol::Git < Commands::Install::Protocol::Base
     when .matches?(Shared::Constants::GH_SHORT_REGEX)
       Log.debug { "(#{name}@#{specifier}) Resolved as a github dependency" }
       Resolver::Github.new(state, name, specifier, parent, dependency_type, skip_cache)
+    when .matches?(/\A[0-9a-f]{40}\z/)
+      # A bare 40-hex specifier is the resolved commit hash pinned in the
+      # parent's lockfile deps by on_resolve. Route it back to the git
+      # resolver: the registry fallback would find the git-keyed entry and
+      # fail while trying to store a git dist as a registry tarball.
+      Log.debug { "(#{name}@#{specifier}) Resolved as a pinned git commit" }
+      Resolver::Git.new(state, name, specifier, parent, dependency_type, skip_cache)
     end
   end
 end

--- a/packages/commands/install/protocol/git/resolver.cr
+++ b/packages/commands/install/protocol/git/resolver.cr
@@ -9,7 +9,12 @@ end
 
 module Commands::Install::Protocol::Git::Resolver
   private abstract struct Base < Commands::Install::Protocol::Resolver
-    getter git_remote : ::Git::Remote
+    # Lazily constructed: a bare commit-hash specifier (the on_resolve pin
+    # in the parent's lockfile deps) is resolved entirely from the lockfile,
+    # so the remote must not be built (and validated) for the pinned path.
+    getter git_remote : ::Git::Remote do
+      ::Git::Remote.new(@specifier.to_s, Reporter::ReporterPrependPipe.new(@state.reporter))
+    end
 
     def initialize(
       state,
@@ -20,7 +25,6 @@ module Commands::Install::Protocol::Git::Resolver
       skip_cache = false
     )
       super
-      @git_remote = ::Git::Remote.new(@specifier.to_s, Reporter::ReporterPrependPipe.new(@state.reporter))
     end
 
     def resolve(*, pinned_version : String? = nil) : Data::Package
@@ -34,8 +38,14 @@ module Commands::Install::Protocol::Git::Resolver
     end
 
     def fetch_metadata : Data::Package
-      commit_hash = @git_remote.commitish_hash
-      cache_key = Digest::SHA1.hexdigest("#{@git_remote.short_key}")
+      # A bare commit-hash specifier is the on_resolve pin: the entry must
+      # already be in the lockfile, so a fetch here means the lockfile is
+      # inconsistent (the pin exists without the resolved entry).
+      if specifier.to_s.matches?(/\A[0-9a-f]{40}\z/)
+        raise "The git commit #{specifier} for #{@name} is pinned in the lockfile but its entry is missing. Regenerate it with `zap i`."
+      end
+      commit_hash = git_remote.commitish_hash
+      cache_key = Digest::SHA1.hexdigest("#{git_remote.short_key}")
       metadata_cache_key = "#{@name}__git:#{cache_key}.package.json"
       cloned_repo_path = Path.new(Dir.tempdir, cache_key)
 
@@ -47,7 +57,7 @@ module Commands::Install::Protocol::Git::Resolver
           clone_to(cloned_repo_path) unless cloned || metadata_cached
           Data::Package.init(metadata_cached && metadata_path ? metadata_path : cloned_repo_path, append_filename: !metadata_cached).tap do |pkg|
             @state.store.store_file(metadata_cache_key, pkg.to_json) unless metadata_cached
-            pkg.dist = Data::Package::Dist::Git.new(commit_hash, specifier.to_s, @git_remote.key, cache_key)
+            pkg.dist = Data::Package::Dist::Git.new(commit_hash, specifier.to_s, git_remote.key, cache_key)
           end
         end
       end
@@ -91,7 +101,7 @@ module Commands::Install::Protocol::Git::Resolver
     end
 
     protected def clone_to(path : Path | String)
-      @git_remote.clone(path)
+      git_remote.clone(path)
     end
 
     private def prepare_package(
@@ -144,7 +154,7 @@ module Commands::Install::Protocol::Git::Resolver
     end
 
     protected def clone_to(path : Path | String)
-      api_url = "https://api.github.com/repos/#{@raw_version.to_s.split('#')[0]}/tarball/#{@git_remote.commitish || ""}"
+      api_url = "https://api.github.com/repos/#{@raw_version.to_s.split('#')[0]}/tarball/#{git_remote.commitish || ""}"
       tarball_url = HTTP::Client.get(api_url).headers["Location"]?
       raise "Failed to fetch package location from Github at #{api_url}" unless tarball_url && !tarball_url.empty?
       Utils::TarGzip.download_and_unpack(tarball_url, path)

--- a/packages/commands/install/protocol/registry/resolver.cr
+++ b/packages/commands/install/protocol/registry/resolver.cr
@@ -68,6 +68,30 @@ struct Commands::Install::Protocol::Registry::Resolver < Commands::Install::Prot
     )
   end
 
+  # The highest already-resolved version of the package whose declared
+  # range accepts it, or nil when none does (prefer-dedupe). The candidates
+  # are the versions actually in use in the tree: the lockfile entries and
+  # the resolutions of the current run, across the root, the workspace
+  # members, and third-party subtrees of the same registry.
+  def dedupe_candidate(name : String, declared_range : String) : Data::Package?
+    range = Semver.parse?(declared_range)
+    return nil unless range
+    best = nil
+    state.lockfile.packages_lock.read do
+      state.lockfile.packages.each_value do |pkg|
+        next unless pkg.name == name
+        next unless pkg.kind.registry?
+        dist = pkg.dist
+        # The tarball must come from the same registry base (the trailing
+        # slash avoids matching a sibling registry with a longer path).
+        next unless dist.is_a?(Data::Package::Dist::Registry) && dist.tarball.starts_with?(@base_url.to_s.rstrip('/') + "/")
+        next unless range.satisfies?(pkg.version)
+        best = pkg if best.nil? || Semver::Version.parse(pkg.version) > Semver::Version.parse(best.version)
+      end
+    end
+    best
+  end
+
   def store?(metadata : Data::Package, &on_downloading) : Bool
     state.store.with_lock(metadata, state.config) do
       next false if state.store.package_is_cached?(metadata)

--- a/packages/commands/install/protocol/resolver.cr
+++ b/packages/commands/install/protocol/resolver.cr
@@ -32,6 +32,13 @@ abstract struct Commands::Install::Protocol::Resolver
   abstract def valid?(metadata : Data::Package) : Bool
   abstract def store?(metadata : Data::Package, &on_downloading) : Bool
 
+  # The highest already-used version of the package that satisfies the
+  # declared range (prefer-dedupe). Only the registry resolver has
+  # already-resolved candidates; the other protocols resolve fresh.
+  def dedupe_candidate(name : String, declared_range : String) : Data::Package?
+    nil
+  end
+
   protected def on_resolve(pkg : Data::Package)
     aliased_name = @name.pipe { |name| name.is_a?(Aliased) ? name.alias : nil }
     parent_package = parent

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -66,10 +66,11 @@ module Commands::Install::Resolver
       # Bust the lockfile cache for the packages being updated. With
       # --recursive the whole transitive tree under a matched package is
       # re-resolved too (an ancestor match propagates the bust downwards).
-      bust_pinned_cache = (is_root || config.update_recursive) && (config.update_all || update_target?(config.updated_packages, name) || (config.update_recursive && config.updated_packages.any? do |pattern|
+      bust_pinned_cache = !dedupe_disabled(state) && (is_root || config.update_recursive) && (config.update_all || update_target?(config.updated_packages, name) || (config.update_recursive && config.updated_packages.any? do |pattern|
         name_pattern, _range = Utils::Misc.parse_key(pattern)
         !name_pattern.starts_with?('!') && ancestors.any? { |a| ::File.match?(name_pattern, a.name) }
       end))
+
 
       if version_or_alias.is_a?(Data::Package::Alias)
         version = version_or_alias.to_s
@@ -89,6 +90,30 @@ module Commands::Install::Resolver
       )
     end
     changed
+  end
+
+  # Whether the install is an update run (any re-resolution is
+  # deliberate and must not be deduplicated against the stale lockfile).
+  private def self.update_in_progress(config : Commands::Install::Config) : Bool
+    config.update_all || config.update_latest || config.updated_packages.size > 0
+  end
+
+  # Whether prefer-dedupe is enabled: the install config env var wins,
+  # then the package.json zap config, then the default (on).
+  private def self.prefer_dedupe(state : Commands::Install::State) : Bool
+    env = state.install_config.prefer_dedupe
+    return env unless env.nil?
+    config = state.context.main_package.zap_config.try(&.prefer_dedupe)
+    config.nil? ? true : config
+  end
+
+  # Whether the one-shot dedupe pass (`zap dedupe`) is ineffective: the
+  # prefer-dedupe option gates the whole dedupe machinery. With the option
+  # off the pass degrades to a plain install — the pins stay authoritative
+  # and nothing re-resolves or collapses — instead of silently upgrading
+  # the tree to the newest registry versions.
+  private def self.dedupe_disabled(state : Commands::Install::State) : Bool
+    state.install_config.dedupe && !prefer_dedupe(state)
   end
 
   # Whether a dependency is targeted by the update patterns (pnpm parity):
@@ -280,6 +305,25 @@ module Commands::Install::Resolver
       end
       # Attempt to use the package data from the lockfile
       maybe_metadata = resolver.get_pinned_metadata(name) unless bust_pinned_cache
+      # prefer-dedupe: when no exact lockfile key matches, reuse the
+      # highest already-used version of the package that satisfies the
+      # declared range instead of resolving a fresh one. Skip during
+      # updates: an update re-resolves deliberately and must not collapse
+      # back to the stale lockfile versions. A dedupe pass (`zap dedupe`)
+      # always resolves to the used versions: with the option off it
+      # collapses nothing but keeps the pins instead of re-resolving
+      # fresh (no surprise update).
+      if maybe_metadata.nil? && ((state.install_config.dedupe && !dedupe_disabled(state)) || (!bust_pinned_cache && !update_in_progress(state.install_config) && prefer_dedupe(state)))
+        maybe_metadata = resolver.dedupe_candidate(name, version)
+        if maybe_metadata && package
+          # The dedupe candidate reuses an already-resolved version without
+          # a fresh `resolver.resolve`, so the `on_resolve` pin (the resolved
+          # version recorded in the parent's specifier) never runs. Record it
+          # in the parent — the lockfile root for direct dependencies — to
+          # keep the lockfile's exact-pin invariant.
+          parent.try &.dependency_specifier(name, maybe_metadata.not_nil!.version, type)
+        end
+      end
       # Check if the data from the lockfile is still valid (direct deps can be modified in the package.json file or through the cli)
       if maybe_metadata && is_direct_dependency
         maybe_metadata = nil unless resolver.valid?(maybe_metadata)
@@ -302,7 +346,7 @@ module Commands::Install::Resolver
         # In update contexts the lockfile entry is stale (its dependency pins
         # are resolved versions, not declared ranges), so the freshly resolved
         # metadata drives the subtree resolution.
-        _metadata = (state.install_config.update_recursive ? metadata_ref : (lockfile_metadata || metadata_ref))
+        _metadata = ((state.install_config.update_recursive && !dedupe_disabled(state)) ? metadata_ref : (lockfile_metadata || metadata_ref))
         # The infinite-loop guard is per key, tracked on the state: the fresh
         # metadata is a new object on every visit (with --recursive), so a
         # flag on the package itself would never trip, re-resolving the same
@@ -310,26 +354,33 @@ module Commands::Install::Resolver
         already_resolved = !state.resolved_keys.add?(metadata_key)
 
         # Forcefully fetch the metadata from the registry if the force_metadata_retrieval option is enabled
-        if (forced_retrieval = lockfile_cached && force_metadata_retrieval && !already_resolved)
+        if (forced_retrieval = lockfile_cached && force_metadata_retrieval && !dedupe_disabled(state) && !already_resolved)
           Log.debug { "(#{metadata_key}) Forcing metadata retrieval #{(package ? "[parent: #{package.key}]" : "")}" }
           fresh_metadata = resolver.resolve(pinned_version: _metadata.version)
-          _metadata.override_dependencies!(fresh_metadata)
+          if state.install_config.dedupe
+            # The dedupe pass re-resolves transitives against the declared
+            # ranges: the lockfile pins are exact versions, so keeping them
+            # would make the subtree uncollapsible. The fresh manifest's
+            # declared ranges replace the pins for the subtree resolution.
+            _metadata.dependencies = fresh_metadata.dependencies
+            _metadata.optional_dependencies = fresh_metadata.optional_dependencies
+            _metadata.peer_dependencies = fresh_metadata.peer_dependencies
+            _metadata.peer_dependencies_meta = fresh_metadata.peer_dependencies_meta
+          else
+            _metadata.override_dependencies!(fresh_metadata)
+          end
         end
 
-        # Apply package extensions unless the package is already in the lockfile
-        apply_package_extensions(_metadata, state: state) if forced_retrieval || !lockfile_metadata || state.install_config.update_recursive
+        # Apply package extensions unless the package is already in the
+        # lockfile, or when an update re-resolved it for the first time in
+        # this run (a later visit must not re-apply the extension over the
+        # pins the subtree resolution just wrote).
+        should_store = !lockfile_metadata || forced_retrieval || (state.install_config.update_recursive && !dedupe_disabled(state) && !already_resolved)
+        apply_package_extensions(_metadata, state: state) if should_store
         # Flag transitive overrides
         flag_transitive_overrides(_metadata, ancestors, state)
-        # Mark the package and store its parents
-        # Used to prevent packages being pruned in the lockfile
-        _metadata.dependents << package if package
 
-        # Mutate only if the package is not already in the lockfile, or when
-        # an update re-resolved it for the first time in this run. The
-        # dependency pins are written after this store (as the children
-        # resolve), so re-storing a fresh manifest on a later visit would
-        # wipe them and replace them with the declared ranges.
-        if !lockfile_metadata || forced_retrieval || (state.install_config.update_recursive && !already_resolved)
+        if should_store
           Log.debug { "(#{metadata_key}) Saving package metadata in the lockfile #{(package ? "[parent: #{package.key}]" : "")}" }
           # Remove dev dependencies
           _metadata.dev_dependencies = nil
@@ -339,6 +390,14 @@ module Commands::Install::Resolver
           end
         end
 
+        # Register the parent in the entry that survives in the lockfile:
+        # the re-stored metadata on the first visit, the existing entry on
+        # later visits. The update_recursive resolution re-runs on fresh
+        # objects, so registering into _metadata alone would lose the
+        # dependents (and the roots attribution) of every visit after the
+        # first.
+        stored_metadata = should_store ? _metadata : lockfile_metadata
+        stored_metadata.try { |m| m.dependents << package } if package
         package.add_dependency_ref(_metadata, type) if package
 
         _metadata

--- a/packages/commands/spec/install/integration/check_resolutions._spec.cr
+++ b/packages/commands/spec/install/integration/check_resolutions._spec.cr
@@ -16,6 +16,21 @@ describe "check resolutions", tags: "integration" do
     end
   end
 
+  it "passes when an aliased and a direct dependency resolve the same package to different versions" do
+    It.with_registry do |registry|
+      registry.add("real", "1.0.0", It.pkg("real", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("real", "2.0.0", It.pkg("real", "2.0.0"), {"index.js" => "2.0.0"})
+      # The aliased dep resolves the real package first (manifest order), so
+      # its ref (which carries the real name) precedes the direct dep's ref.
+      registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"al" => "npm:real@^1.0.0", "real" => "^2.0.0"}), {"index.js" => "p"})
+
+      ic = Commands::Install::Config.new.copy_with(check_resolutions: true)
+      It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}}), install_config: ic) do |project|
+        File.read(project / "node_modules/real/index.js").should eq("2.0.0")
+      end
+    end
+  end
+
   it "raises when a direct resolution was tampered in place" do
     It.with_registry do |registry|
       registry.add("a", "1.0.0", It.pkg("a", "1.0.0"), {"index.js" => "a"})

--- a/packages/commands/spec/install/integration/dedupe._spec.cr
+++ b/packages/commands/spec/install/integration/dedupe._spec.cr
@@ -1,0 +1,837 @@
+require "../../../catalog/catalog"
+require "./spec_helper"
+
+# The prefer-dedupe resolution: when a compatible version of a package is
+# already used in the tree, a new dependency resolves to the highest used
+# version instead of a fresh one (pnpm's prefer-dedupe semantics).
+# A plain install with the given package.json; returns the project dir.
+private def dedupe_install(registry, package_json : String) : Path
+  tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+  Dir.mkdir_p(tmpdir)
+  File.write(tmpdir / "package.json", package_json)
+  File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+  config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+  ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+  Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+  tmpdir
+end
+
+describe "prefer-dedupe", tags: "integration" do
+  it "collapses two compatible ranges into the highest used version" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+
+      project = dedupe_install(registry, %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+      begin
+        # Both ranges are compatible with 1.2.0: one version in the tree.
+        lockfile = Data::Lockfile.new(project)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.2.0")
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "does not downgrade when no used version satisfies the range" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "2.0.0", It.pkg("dep", "2.0.0"), {"index.js" => "2.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^2.0.0"}), {"index.js" => "b"})
+
+      project = dedupe_install(registry, %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+      begin
+        # The ranges are incompatible: both versions stay.
+        lockfile = Data::Lockfile.new(project)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.sort.should eq(["dep@1.0.0", "dep@2.0.0"])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "shares one version across workspace members" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.3.0", It.pkg("dep", "1.3.0"), {"index.js" => "1.3.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-ws-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","dependencies":{"dep":"^1.0.0"}}))
+        File.write(ws_root / "packages/b/package.json", %({"name":"b","version":"1.0.0","dependencies":{"dep":"~1.3.0"}}))
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(ws_root)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.3.0")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "keeps the fresh resolution when prefer_dedupe is disabled" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+
+      # With the dedupe disabled, the two ranges resolve independently and
+      # stay distinct when the registry offers a version only one accepts:
+      # ^1.0.0 picks 1.2.0 while ~1.0.0 can only use 1.0.0.
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.0.0"}), {"index.js" => "b"})
+
+      project = dedupe_install(registry, %({"name":"app","version":"1.0.0","zap":{"prefer_dedupe":false},"dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+      begin
+        lockfile = Data::Lockfile.new(project)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.sort.should eq(["dep@1.0.0", "dep@1.2.0"])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The one-shot `zap dedupe` pass: a tree that already holds compatible
+  # but different versions (installed before the dedupe existed, or with
+  # the option off) is re-resolved and collapsed into the highest version
+  # in use. The divergence is built with two sequential installs: dep 1.2.0
+  # does not exist when `a` pins 1.0.0, and is published before `b` pins it.
+  # The ranges are declared by the workspace members (direct dependencies),
+  # so the re-resolution still knows them: transitive pins in the lockfile
+  # are exact and stay authoritative.
+  it "collapses a pre-diverged tree with the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-wsdd-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(ws_root / "packages/a")
+      File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":["packages/*"]}))
+      File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        # Stage 1: only member `a` exists; dep 1.2.0 is not published yet,
+        # so `a` pins dep@1.0.0.
+        File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","dependencies":{"dep":"^1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # Stage 2: dep 1.2.0 (and a newer 1.3.0 that only a fresh
+        # resolution would adopt) and member `b` appear; `b` pins dep@1.2.0
+        # while `a` keeps its pin: the tree is diverged.
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("dep", "1.3.0", It.pkg("dep", "1.3.0"), {"index.js" => "1.3.0"})
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "packages/b/package.json", %({"name":"b","version":"1.0.0","dependencies":{"dep":"~1.2.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(ws_root)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.sort.should eq(["dep@1.0.0", "dep@1.2.0"])
+        # The classic linker hoists one version to the root and nests the
+        # other under its parent: two physical copies in the tree.
+        Dir.glob(ws_root / "**/node_modules/dep/package.json").map { |p| JSON.parse(File.read(p))["version"].as_s }.sort.should eq(["1.0.0", "1.2.0"])
+
+        # The one-shot pass re-resolves the whole tree with the dedupe
+        # preference: `a`'s ^1.0.0 accepts the used 1.2.0, so the tree
+        # collapses to a single version.
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(ws_root)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.2.0")
+        # The old nested copy is pruned (its lockfile key is gone) and the
+        # single remaining version is hoisted to the root: exactly one
+        # physical copy, at the top level.
+        Dir.glob(ws_root / "**/node_modules/dep/package.json").map { |p| JSON.parse(File.read(p))["version"].as_s }.should eq(["1.2.0"])
+        JSON.parse(File.read(ws_root / "node_modules/dep/package.json"))["version"].as_s.should eq("1.2.0")
+        File.exists?(ws_root / "packages/a/node_modules/dep").should be_false
+
+        # PROBE: physical layout after the divergence
+        Dir.glob(ws_root / "**/node_modules/dep/package.json").each do |p|
+          v = JSON.parse(File.read(p))["version"]
+          STDERR.puts "PROBE div #{p.gsub(ws_root.to_s, "")} -> dep@#{v}"
+        end
+
+        # The one-shot pass re-resolves the whole tree with the dedupe
+        # preference: `a`'s ^1.0.0 accepts the used 1.2.0, so the tree
+        # collapses to a single version.
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(ws_root)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.2.0")
+
+        # With prefer-dedupe off the pass has nothing to collapse: it must
+        # keep the lockfile pins instead of re-resolving fresh (the tree
+        # would otherwise be silently upgraded to the newest versions).
+        ic3 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true, prefer_dedupe: false)
+        Commands::Install.run(config, ic3, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(ws_root)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.2.0")
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  # A regular root app (no workspaces): the divergence is between two
+  # transitive dependencies, whose declared ranges are not recorded in the
+  # lockfile (only the resolved pins are). The one-shot pass re-fetches the
+  # parents' manifests so the declared ranges drive the re-resolution, and
+  # the physical tree relocates in the same pass.
+  it "collapses a transitive divergence in a regular root app" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+
+      project = Path.new(Dir.tempdir, "zap-nest-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        # dep 1.2.0 and `b` appear; `a` keeps its pin while `b` pins 1.2.0:
+        # the tree diverges and the classic linker nests 1.2.0 under `b`
+        # (the root already holds 1.0.0).
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(project)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.sort.should eq(["dep@1.0.0", "dep@1.2.0"])
+        Dir.glob(project / "**/node_modules/dep/package.json").map { |p| JSON.parse(File.read(p))["version"].as_s }.sort.should eq(["1.0.0", "1.2.0"])
+
+        # The one-shot pass: the declared ranges come back from the fresh
+        # parent manifests, so the transitive divergence collapses, and the
+        # stale nested copy is pruned in the same pass (the surviving
+        # version is hoisted to the root).
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = Data::Lockfile.new(project)
+        dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.size.should eq(1)
+        dep_versions.first.should eq("dep@1.2.0")
+        Dir.glob(project / "**/node_modules/dep/package.json").map { |p| JSON.parse(File.read(p))["version"].as_s }.should eq(["1.2.0"])
+        File.exists?(project / "node_modules/b/node_modules/dep").should be_false
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The dedupe candidate path reuses an already-resolved version without a
+  # fresh resolver.resolve, so the on_resolve pin (the resolved version in
+  # the parent's specifier) must be recorded explicitly. The isolated and
+  # pnp linkers key their lookups on name@<resolved version>.
+  ["isolated", "pnp"].each do |strategy_name|
+    it "pins the resolved version when the dedupe candidate is reused (#{strategy_name})" do
+      strategy = strategy_name == "pnp" ? Data::Package::InstallStrategy::Pnp : Data::Package::InstallStrategy::Isolated
+      It.with_registry do |registry|
+        registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+        registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+        project = Path.new(Dir.tempdir, "zap-pin-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy)
+        begin
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+          lockfile = Data::Lockfile.new(project)
+          b = lockfile.packages.values.find { |p| p.name == "b" }
+          b.should_not be_nil
+          b.not_nil!.dependencies.should eq({"dep" => "1.0.0"})
+        ensure
+          FileUtils.rm_rf(project)
+        end
+      end
+    end
+  end
+
+  # The other install strategies must survive the one-shot pass too: the
+  # dedupe restores the declared ranges from the fresh manifests for the
+  # subtree resolution, but the lockfile entries must keep their resolved
+  # pins (the pnp linker keys its lookups on `name@<resolved version>`).
+  ["isolated", "pnp"].each do |strategy_name|
+    it "keeps the resolved pins when deduping with the #{strategy_name} strategy" do
+      strategy = strategy_name == "pnp" ? Data::Package::InstallStrategy::Pnp : Data::Package::InstallStrategy::Isolated
+      It.with_registry do |registry|
+        registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+        registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+        project = Path.new(Dir.tempdir, "zap-strat-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy)
+        begin
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+          registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+          registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+          File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+          ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+          Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+
+          lockfile = Data::Lockfile.new(project)
+          dep_versions = lockfile.packages.keys.select { |k| k.starts_with?("dep@") }
+          dep_versions.size.should eq(1)
+          dep_versions.first.should eq("dep@1.2.0")
+          b = lockfile.packages.values.find { |p| p.name == "b" }
+          b.should_not be_nil
+          b.not_nil!.dependencies.should eq({"dep" => "1.2.0"})
+        ensure
+          FileUtils.rm_rf(project)
+        end
+      end
+    end
+  end
+end
+
+describe "dedupe candidate pins", tags: "integration" do
+  it "pins a shared devDependency into the root even when resolved via the candidate" do
+    It.with_registry do |registry|
+      registry.add("chalk", "4.1.2", It.pkg("chalk", "4.1.2"), {"index.js" => "c"})
+      registry.add("other", "1.0.0", It.pkg("other", "1.0.0", dependencies: {"chalk" => "4.1.2"}), {"index.js" => "o"})
+      project = Path.new(Dir.tempdir, "zap-cand-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project / "apps" / "app1")
+        File.write(project / "package.json", %({"name":"root","version":"1.0.0","private":true,"workspaces":["apps/*"],"dependencies":{"app1":"workspace:*"},"devDependencies":{"chalk":"4.1.2"}}))
+        File.write(project / "apps/app1/package.json", %({"name":"app1","version":"1.0.0","dependencies":{"other":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: Data::Package::InstallStrategy::Isolated)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.roots["root"].pinned_dependencies.try(&.["chalk"]?).should eq("4.1.2")
+        File.exists?(project / "node_modules/chalk").should be_true
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+end
+
+describe "dedupe alias pins", tags: "integration" do
+  it "keeps aliased dependencies as aliases through the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("real", "1.0.0", It.pkg("real", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("real", "1.2.0", It.pkg("real", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"al" => "npm:real@^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-alias-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        a = lf.packages.values.find { |p| p.name == "a" }
+        a.try(&.dependencies).try(&.["al"]?).should eq(Data::Package::Alias.new("real", "1.2.0"))
+        # A bare string pin would make a later install resolve the alias
+        # name from the registry; the reinstall must keep working.
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+end
+
+describe "dedupe corner cases", tags: "integration" do
+  it "collapses shared dependencies under the catalog protocol" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"},"zap":{"catalog":{"dep":"^1.0.0"}}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        lf.packages.keys.any? { |k| k == "dep@1.2.0" }.should be_true
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "applies package extensions to deduped packages" do
+    It.with_registry do |registry|
+      registry.add("extra", "1.0.0", It.pkg("extra", "1.0.0"), {"index.js" => "e"})
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0", dependencies: {"extra" => "1.0.0"}), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"},"zap":{"package_extensions":{"dep@1.0.0":{"dependencies":{"extra":"1.0.0"}}}}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        lf.packages.values.any? { |p| p.name == "extra" }.should be_true
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "dedupes under the classic and classic_shallow strategies" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      [Data::Package::InstallStrategy::Classic, Data::Package::InstallStrategy::Classic_Shallow].each do |strategy|
+        project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+        begin
+          Dir.mkdir_p(project)
+          File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+          File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+          config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+          Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy), raise_on_failure: true, reporter: Reporter::Null.new)
+          lf = Data::Lockfile.new(project)
+          lf.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        ensure
+          FileUtils.rm_rf(project)
+        end
+      end
+    end
+  end
+
+  it "respects overrides through the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"},"overrides":{"dep":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        lf.packages.keys.any? { |k| k == "dep@1.0.0" }.should be_true
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps optional aliases aliased through the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("real", "1.0.0", It.pkg("real", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("real", "1.2.0", It.pkg("real", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", optional_dependencies: {"al" => "npm:real@^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        a = lf.packages.values.find { |p| p.name == "a" }
+        a.try(&.optional_dependencies).try(&.["al"]?).should eq(Data::Package::Alias.new("real", "1.2.0"))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps the manifest untouched through the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        before = File.read(project / "package.json")
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(project / "package.json").should eq(before)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "does not collapse versions during an update" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_recursive: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        lf.packages.keys.any? { |k| k == "dep@1.2.0" }.should be_true
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "does not pick a prerelease for a stable range" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0-beta.1", It.pkg("dep", "1.0.0-beta.1"), {"index.js" => "beta"})
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lf = Data::Lockfile.new(project)
+        lf.packages.keys.any? { |k| k == "dep@1.0.0-beta.1" }.should be_false
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "dedupes with dev dependencies omitted" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"},"devDependencies":{"b":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, omit: [Commands::Install::Config::Omit::Dev])
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # The dev-only subtree (b and its exact dep@1.0.0) is not installed;
+        # the lockfile keeps the full graph (pnpm parity), the physical
+        # tree only holds a's ^1.0.0.
+        File.exists?(project / "node_modules/b").should be_false
+        JSON.parse(File.read(project / "node_modules/dep/package.json"))["version"].as_s.should eq("1.2.0")
+        dep_versions = Data::Lockfile.new(project).packages.keys.select { |k| k.starts_with?("dep@") }
+        dep_versions.sort.should eq(["dep@1.0.0", "dep@1.2.0"])
+        lock_before = File.read(project / "zap.lock")
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        # The one-shot keeps the same tree: nothing new, nothing churned.
+        File.exists?(project / "node_modules/b").should be_false
+        JSON.parse(File.read(project / "node_modules/dep/package.json"))["version"].as_s.should eq("1.2.0")
+        File.read(project / "zap.lock").should eq(lock_before)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps declared ranges in the lockfile root through the one-shot dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","dep":"^1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile = Data::Lockfile.new(project)
+        root = lockfile.roots["app"]
+        root.try(&.dependencies).try(&.["dep"]?).should eq("^1.0.0")
+        root.try(&.pinned_dependencies).try(&.["dep"]?).should eq("1.2.0")
+        # The dedupe must not leave the lockfile churning: a subsequent
+        # install writes an identical file.
+        lock_after_dedupe = File.read(project / "zap.lock")
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(project / "zap.lock").should eq(lock_after_dedupe)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The prefer-dedupe option gates the one-shot pass too: with the option
+  # off, `zap dedupe` degrades to a plain install — a diverged tree keeps
+  # both pins (no collapse) and a stale pin is not silently upgraded to
+  # the newest registry version.
+  it "keeps diverged pins when prefer-dedupe is off through the one-shot pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # dep@1.2.0 and dep@1.3.0 appear later; b pulls in 1.2.0 while a
+        # keeps its stale 1.0.0 pin. A fresh resolution of a's ^1.0.0 would
+        # upgrade to 1.3.0, so the pass must not silently upgrade.
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("dep", "1.3.0", It.pkg("dep", "1.3.0"), {"index.js" => "1.3.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        versions = ->(project : Path) { Data::Lockfile.new(project).packages.keys.select { |k| k.starts_with?("dep@") }.sort }
+        versions.call(project).should eq(["dep@1.0.0", "dep@1.2.0"])
+        lock_before = File.read(project / "zap.lock")
+        # The exact config the CLI builds for `zap dedupe`.
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true, prefer_dedupe: false), raise_on_failure: true, reporter: Reporter::Null.new)
+        versions.call(project).should eq(["dep@1.0.0", "dep@1.2.0"])
+        File.read(project / "zap.lock").should eq(lock_before)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The frozen guard must catch a dedupe that would update the lockfile
+  # (CI parity): a collapsible divergence where the collapse changes pins.
+  it "refuses to write a diverged lockfile under frozen-lockfile" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # dep@1.2.0 appears later; b pulls it in while a keeps its stale
+        # 1.0.0 pin (its ^1.0.0 range accepts the collapse).
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Data::Lockfile.new(project).packages.keys.count { |k| k.starts_with?("dep@") }.should eq(2)
+        raised = false
+        begin
+          Commands::Install.run(config, ic.copy_with(frozen_lockfile: true, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        rescue ex
+          raised = true
+          ex.message.not_nil!.should contain("frozen-lockfile")
+        end
+        raised.should be_true
+        # The lockfile is untouched.
+        Data::Lockfile.new(project).packages.keys.count { |k| k.starts_with?("dep@") }.should eq(2)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+end
+
+  # `zap add` inherits the dedupe: an added dependency whose range an
+  # already-used version satisfies resolves to it instead of the newest
+  # registry version, so the tree keeps a single copy. The saved
+  # specifier keeps the declared range (npm parity).
+  it "dedupes an added dependency against the versions in use" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # dep@1.2.0 appears later: a fresh resolution of ^1.0.0 would pick
+        # it, but the dedupe keeps the version already in use (1.0.0).
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        Commands::Install.run(config, ic.copy_with(added_packages: ["dep@^1.0.0"]), raise_on_failure: true, reporter: Reporter::Null.new)
+        manifest = JSON.parse(File.read(project / "package.json"))
+        manifest["dependencies"]["dep"].as_s.should eq("^1.0.0")
+        lockfile = Data::Lockfile.new(project)
+        lockfile.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(1)
+        lockfile.packages.keys.find { |k| k.starts_with?("dep@") }.should eq("dep@1.0.0")
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # A file: dependency and a registry dependency of the same name coexist:
+  # the dedupe candidates only come from registry entries, so the exotic
+  # source never absorbs or is absorbed by the registry resolution.
+  it "keeps a file dependency distinct from a registry dependency of the same name" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project / "local-dep")
+        File.write(project / "local-dep/package.json", %({"name":"dep","version":"2.0.0","main":"index.js"}))
+        File.write(project / "local-dep/index.js", "local")
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","dep":"file:local-dep"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile = Data::Lockfile.new(project)
+        lockfile.packages.keys.count { |k| k.starts_with?("dep@") }.should eq(2)
+        lockfile.packages.keys.any? { |k| k == "dep@1.2.0" }.should be_true
+        JSON.parse(File.read(project / "node_modules/dep/package.json"))["version"].as_s.should eq("2.0.0")
+        JSON.parse(File.read(project / "node_modules/a/node_modules/dep/package.json"))["version"].as_s.should eq("1.2.0")
+        # The tree is stable: a reinstall does not churn.
+        lock_after = File.read(project / "zap.lock")
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(project / "zap.lock").should eq(lock_after)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # A package extension rewrites a dependency's declared range on every
+  # visit of the one-shot pass. The subtree resolution pins the resolved
+  # version afterwards, but a later parent's visit re-applied the extension
+  # and reverted the pin to the range. The extension must apply once per
+  # package per run. The mid chain schedules the second visit of ext after
+  # the first visit's subtree pin (the pipeline runs fibers in spawn
+  # order), so the revert is deterministic.
+  it "keeps the pins when a package extension matches a shared package" do
+    It.with_registry do |registry|
+      registry.add("shared", "1.0.0", It.pkg("shared", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("shared", "1.2.0", It.pkg("shared", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("ext", "1.0.0", It.pkg("ext", "1.0.0", dependencies: {"shared" => "^1.0.0"}), {"index.js" => "e"})
+      registry.add("mid1", "1.0.0", It.pkg("mid1", "1.0.0", dependencies: {"ext" => "^1.0.0"}), {"index.js" => "m1"})
+      registry.add("mid2", "1.0.0", It.pkg("mid2", "1.0.0", dependencies: {"mid1" => "^1.0.0"}), {"index.js" => "m2"})
+      registry.add("p1", "1.0.0", It.pkg("p1", "1.0.0", dependencies: {"ext" => "^1.0.0"}), {"index.js" => "1"})
+      registry.add("p2", "1.0.0", It.pkg("p2", "1.0.0", dependencies: {"mid2" => "^1.0.0"}), {"index.js" => "2"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"p1":"1.0.0","p2":"1.0.0"},"zap":{"package_extensions":{"ext@1.0.0":{"dependencies":{"shared":">=1.0.0"}}}}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile = Data::Lockfile.new(project)
+        ext = lockfile.packages.values.find { |p| p.name == "ext" }
+        ext.should_not be_nil
+        ext.not_nil!.dependencies.should eq({"shared" => "1.2.0"})
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The roots attribution on a workspace entry comes from the dependents
+  # graph, which the one-shot builds on fresh objects. Registering the
+  # dependents into those discarded objects dropped every parent after the
+  # first, so a shared workspace package listed only one root and the
+  # lockfile churned on the next install. The dependents must land on the
+  # entry that survives in the lockfile.
+  it "keeps the full roots attribution on shared workspace packages through the one-shot pass" do
+    It.with_registry do |registry|
+      ws_root = Path.new(Dir.tempdir, "zap-ws-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        Dir.mkdir_p(ws_root / "packages/shared")
+        File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/shared/package.json", %({"name":"shared","version":"1.0.0","main":"index.js"}))
+        File.write(ws_root / "packages/shared/index.js", "s")
+        File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","dependencies":{"shared":"workspace:*"}}))
+        File.write(ws_root / "packages/b/package.json", %({"name":"b","version":"1.0.0","dependencies":{"shared":"workspace:*"}}))
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile = Data::Lockfile.new(ws_root)
+        shared = lockfile.packages.values.find { |p| p.name == "shared" }
+        shared.should_not be_nil
+        roots_after_install = shared.not_nil!.roots.to_a.sort
+        roots_after_install.should contain("a")
+        roots_after_install.should contain("b")
+        Commands::Install.run(config, ic.copy_with(dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true), raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile = Data::Lockfile.new(ws_root)
+        shared = lockfile.packages.values.find { |p| p.name == "shared" }
+        shared.should_not be_nil
+        shared.not_nil!.roots.to_a.sort.should eq(roots_after_install)
+        # No churn on the next install.
+        lock_after_dedupe = File.read(ws_root / "zap.lock")
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.read(ws_root / "zap.lock").should eq(lock_after_dedupe)
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end

--- a/packages/commands/spec/install/integration/git._spec.cr
+++ b/packages/commands/spec/install/integration/git._spec.cr
@@ -46,4 +46,28 @@ describe "git dependencies", tags: "integration" do
       end
     end
   end
+
+  it "reinstalls a transitive git dependency from the lockfile pin" do
+    It.with_registry do |registry|
+      repo = Path.new(Dir.tempdir, "zap-git-#{Random::Secure.hex(4)}")
+      begin
+        It.make_git_repo(repo, %({"name":"git-pkg","version":"1.0.0","main":"index.js"}), {"index.js" => "from-git"})
+        registry.add("parent", "1.0.0", It.pkg("parent", "1.0.0", dependencies: {"git-pkg" => "git+file://#{repo}"}), {"index.js" => "p"})
+
+        It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"parent":"1.0.0"}})) do |project|
+          # The parent's lockfile deps pin the git dependency by its resolved
+          # commit hash; a second install must route the bare-hash specifier
+          # back to the git resolver instead of the registry fallback.
+          Commands::Install.run(
+            Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true),
+            Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true),
+            raise_on_failure: true, reporter: Reporter::Null.new
+          )
+          File.read(project / "node_modules/parent/node_modules/git-pkg/index.js").should eq("from-git")
+        end
+      ensure
+        FileUtils.rm_rf(repo)
+      end
+    end
+  end
 end

--- a/packages/commands/spec/install/integration/git_edge_cases._spec.cr
+++ b/packages/commands/spec/install/integration/git_edge_cases._spec.cr
@@ -44,7 +44,7 @@ describe "git dependencies edge cases", tags: "integration" do
         File.write(repo / "index.js", "v2")
         Process.run("git", ["-C", repo.to_s, "add", "."])
         env = {"GIT_AUTHOR_NAME" => "zap-tests", "GIT_AUTHOR_EMAIL" => "zap-tests@example.com", "GIT_COMMITTER_NAME" => "zap-tests", "GIT_COMMITTER_EMAIL" => "zap-tests@example.com"}
-        Process.run("git", ["-C", repo.to_s, "commit", "-q", "-m", "v2"], env: env)
+        Process.run("git", ["-C", repo.to_s, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "v2"], env: env)
         Process.run("git", ["-C", repo.to_s, "tag", "2.0.0"])
 
         It.install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"git-semver":"git+file://#{repo}#semver:^1.0.0"}})) do |project|

--- a/packages/commands/spec/install/integration/relocation._spec.cr
+++ b/packages/commands/spec/install/integration/relocation._spec.cr
@@ -1,0 +1,336 @@
+require "../../../catalog/catalog"
+require "./spec_helper"
+
+# The classic writer removes stale physical copies as a byproduct of
+# re-deriving each package's placement: a copy at the direct parent's
+# node_modules is only valid while the package installs at the parent's
+# own level. These specs pin the PHYSICAL layout, not just the lockfile,
+# across hoisting alignments, partially-installed trees, and the other
+# install strategies.
+
+# Returns [{relative_package_dir, version}] of every physical copy of *name*.
+private def physical_copies(project : Path, name : String) : Array({String, String})
+  Dir.glob(project / "**/node_modules" / name / "package.json").map do |p|
+    rel = Path.new(p).parent.to_s.gsub(project.to_s, "").lstrip('/')
+    {rel, JSON.parse(File.read(p))["version"].as_s}
+  end.sort
+end
+
+# A plain install; returns the project dir.
+private def install_project(registry, package_json : String, strategy = Data::Package::InstallStrategy::Classic) : Path
+  project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+  Dir.mkdir_p(project)
+  File.write(project / "package.json", package_json)
+  File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+  config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+  ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy)
+  Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+  project
+end
+
+describe "classic relocation", tags: "integration" do
+  it "keeps the physical tree stable on an up-to-date pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+
+      project = install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+      begin
+        # The first install with prefer-dedupe on: both ranges collapse to
+        # 1.2.0, hoisted at the root.
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+
+        # The up-to-date pass re-derives the same placement: nothing moves.
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "removes a sibling subtree's moot nested copy regardless of the resolution order" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        # `b` is declared first: its dep resolves before `a`'s.
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"b":"1.0.0","a":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/b/node_modules/dep", "1.2.0"}, {"node_modules/dep", "1.0.0"}])
+
+        # The dedupe collapses both to 1.2.0. Whichever subtree resolves
+        # first lands at the root; the other's nested copy is moot and the
+        # writer removes it in the same pass.
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+        File.exists?(project / "node_modules/b/node_modules").should be_false
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "removes a mid-tree copy when its subtree disappears" do
+    It.with_registry do |registry|
+      registry.add("dep", "0.9.0", It.pkg("dep", "0.9.0"), {"index.js" => "0.9.0"})
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("x", "1.0.0", It.pkg("x", "1.0.0", dependencies: {"dep" => "^0.9.0"}), {"index.js" => "x"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"x":"1.0.0","a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # a's dep lands at the root; x's dep stays at x's (mid-tree) level
+        # because the root holds an incompatible version.
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.0.0"}, {"node_modules/x/node_modules/dep", "0.9.0"}])
+
+        # Removing x drops its subtree (the mid-tree copy included) in the
+        # same pass.
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.0.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps a peer dependency's tree stable on reinstalls" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0", peer_dependencies: {"a" => "^1.0.0"}), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+
+      project = install_project(registry, %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      begin
+        # The dep is hoisted at the root; its peer `a` resolves next to it.
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.0.0"}])
+
+        # Reinstalls leave the peer-satisfying tree in place.
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.0.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps a nohoist workspace copy nested" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+
+      ws_root = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(ws_root / "packages" / "a")
+      File.write(ws_root / "package.json", %({"name":"ws","version":"1.0.0","workspaces":{"packages":["packages/*"],"nohoist":["**/dep"]}}))
+      File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+      File.write(ws_root / "packages/a/package.json", %({"name":"a","version":"1.0.0","dependencies":{"dep":"1.0.0"}}))
+      config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(ws_root, "dep").should eq([{"packages/a/node_modules/dep", "1.0.0"}])
+
+        # A reinstall keeps the nohoist copy.
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(ws_root, "dep").should eq([{"packages/a/node_modules/dep", "1.0.0"}])
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "sweeps a partially-installed stale copy left on disk" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/b/node_modules/dep", "1.2.0"}, {"node_modules/dep", "1.0.0"}])
+
+        # Simulate an interrupted pass: a stale copy without a matching
+        # installed-state entry, plus an orphan nested directory.
+        stale = project / "node_modules/b/node_modules/dep"
+        FileUtils.rm_rf(stale)
+        Dir.mkdir_p(stale)
+        File.write(stale / "package.json", %({"name":"dep","version":"0.5.0"}))
+        Dir.mkdir_p(project / "node_modules/b/node_modules/ghost")
+        File.write(project / "node_modules/b/node_modules/ghost/package.json", %({"name":"ghost","version":"1.0.0"}))
+
+        # The writer sweeps b's nested copy when its dep lands at the root.
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "replaces a copy in place when its version changes" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.0.0"}])
+
+        # The update bumps the range to 1.2.0 at the same location: the
+        # copy is replaced in place (key mismatch -> re-link), not removed.
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, update_all: true, update_recursive: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  it "keeps the tree stable on a subsequent dedupe pass" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+
+        # A second dedupe pass is a no-op on the physical tree.
+        Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/dep", "1.2.0"}])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
+  # The non-hoisting strategies have their own linkers and store layouts;
+  # the dedupe must leave their trees stable across the following pass.
+  ["isolated", "pnp"].each do |strategy_name|
+    it "keeps the deduped tree stable on reinstalls with the #{strategy_name} strategy" do
+      strategy = strategy_name == "pnp" ? Data::Package::InstallStrategy::Pnp : Data::Package::InstallStrategy::Isolated
+      It.with_registry do |registry|
+        registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+        registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+        project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy)
+        begin
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+          registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+          registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+          File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+          ic2 = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, strategy: strategy, dedupe: true, update_all: true, update_recursive: true, force_metadata_retrieval: true)
+          Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+          lockfile = Data::Lockfile.new(project)
+          lockfile.packages.keys.select { |k| k.starts_with?("dep@") }.should eq(["dep@1.2.0"])
+
+          # The following plain install (and another dedupe) is stable.
+          Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+          Commands::Install.run(config, ic2, raise_on_failure: true, reporter: Reporter::Null.new)
+          lockfile = Data::Lockfile.new(project)
+          lockfile.packages.keys.select { |k| k.starts_with?("dep@") }.should eq(["dep@1.2.0"])
+        ensure
+          FileUtils.rm_rf(project)
+        end
+      end
+    end
+  end
+
+  # Partial node_modules deletion (a whole subtree or a nested copy
+  # disappears between runs): the reinstall must rebuild exactly the
+  # missing pieces from the lockfile and leave the rest untouched.
+  it "rebuilds a partially-deleted subtree on reinstall" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      project = Path.new(Dir.tempdir, "zap-rel-#{Random::Secure.hex(4)}")
+      Dir.mkdir_p(project)
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"}}))
+      File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+      config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+      ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true)
+      begin
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # dep@1.2.0 appears later; b pulls it in while a keeps its stale
+        # 1.0.0 pin, so the tree genuinely holds both versions.
+        registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+        registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "~1.2.0"}), {"index.js" => "b"})
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0","b":"1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/b/node_modules/dep", "1.2.0"}, {"node_modules/dep", "1.0.0"}])
+        lock_after_install = File.read(project / "zap.lock")
+
+        # Delete b's whole subtree, then reinstall: b and its nested copy
+        # come back, nothing else moves.
+        FileUtils.rm_rf(project / "node_modules/b")
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/b/node_modules/dep", "1.2.0"}, {"node_modules/dep", "1.0.0"}])
+        File.read(project / "zap.lock").should eq(lock_after_install)
+
+        # Delete only the nested copy, then reinstall: it is re-linked in
+        # place without touching the hoisted version.
+        FileUtils.rm_rf(project / "node_modules/b/node_modules/dep")
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        physical_copies(project, "dep").should eq([{"node_modules/b/node_modules/dep", "1.2.0"}, {"node_modules/dep", "1.0.0"}])
+        File.read(project / "zap.lock").should eq(lock_after_install)
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+end

--- a/packages/commands/spec/install/integration/spec_helper.cr
+++ b/packages/commands/spec/install/integration/spec_helper.cr
@@ -262,7 +262,9 @@ module Zap::Integration
     Process.run("git", ["init", "-q", "-b", "main", repo.to_s])
     Process.run("git", ["-C", repo.to_s, "add", "."])
     env = {"GIT_AUTHOR_NAME" => "zap-tests", "GIT_AUTHOR_EMAIL" => "zap-tests@example.com", "GIT_COMMITTER_NAME" => "zap-tests", "GIT_COMMITTER_EMAIL" => "zap-tests@example.com"}
-    Process.run("git", ["-C", repo.to_s, "commit", "-q", "-m", "init"], env: env)
+    # Signing is disabled so the helper works regardless of the developer's
+    # global git config (e.g. commit.gpgsign with an unavailable agent).
+    Process.run("git", ["-C", repo.to_s, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], env: env)
   end
 
   # Runs a block with a fresh fixture registry, stopping it afterwards.

--- a/packages/data/package/fields/config.cr
+++ b/packages/data/package/fields/config.cr
@@ -34,7 +34,8 @@ class Data::Package
       named_registries : Hash(String, String)? = nil,
       catalog : Hash(String, String)? = nil,
       catalogs : Hash(String, Hash(String, String))? = nil,
-      network_protocol : String? = nil do
+      network_protocol : String? = nil,
+      prefer_dedupe : Bool? = nil do
       include JSON::Serializable
       include YAML::Serializable
       include MessagePack::Serializable

--- a/spec/e2e/dedupe.cr
+++ b/spec/e2e/dedupe.cr
@@ -1,0 +1,77 @@
+require "./harness"
+
+# The one-shot `zap dedupe` command against the real registry: a tree
+# genuinely holding two versions of the same package collapses to the
+# highest version in use, the physical tree relocates, and the lockfile
+# stops churning.
+describe "zap dedupe against a real registry", tags: "e2e" do
+  it "collapses a diverged transitive to the highest in-use version" do
+    # The root dependency is declared as a range: the dedupe must keep the
+    # declared specifier in the lockfile root and only move the pins.
+    project = E2E.make_project(%({"chalk":"2.4.2","debug":"4.3.4","supports-color":"^5.3.0"}), E2E.auth_npmrc)
+    ok, output = E2E.zap(project, "install", "--frozen-lockfile=false")
+    ok.should be_true, "install failed: #{output}"
+    E2E.assert_installed(project, ["chalk", "debug", "supports-color"])
+
+    # Rewire the tree into a genuine divergence: chalk's transitive pin
+    # drops to 5.3.0 while the direct dependency stays at 5.5.0 (the
+    # highest in use), as a stale lockfile written before 5.5.0 existed
+    # would have left it.
+    lock_path = File.join(project, "zap.lock")
+    lock = File.read(lock_path)
+    # Rewire chalk's transitive pin inside its own entry (the root's
+    # pinned_dependencies also lists 5.5.0 and must stay untouched).
+    chalk_match = lock.match(/\n  chalk@2\.4\.2:\n((?:    .*\n)*)/)
+    chalk_match.should_not be_nil, "chalk entry not found in lockfile"
+    chalk_block = chalk_match.not_nil![1]
+    chalk_block.should contain("supports-color: 5.5.0"), "chalk entry missing the 5.5.0 pin: #{chalk_block}"
+    rewired = chalk_block.sub("supports-color: 5.5.0", "supports-color: 5.3.0")
+    lock = lock.sub(chalk_block, rewired)
+    entry_530 = <<-YAML
+      supports-color@5.3.0:
+        name: supports-color
+        version: 5.3.0
+        dependencies:
+          has-flag: 3.0.0
+        engines:
+          node: '>=4'
+        roots:
+        - e2e
+        dist:
+          tarball: #{E2E.base_url}/supports-color/-/supports-color-5.3.0.tgz
+          shasum: 5b24ac15db80fa927cf5227a4a33fd3c4c7676c0
+          integrity: sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==
+    YAML
+    lock = lock.sub("  supports-color@5.5.0:", entry_530 + "\n" + "  supports-color@5.5.0:")
+    File.write(lock_path, lock)
+
+    # Materialize the diverged tree: root node_modules holds 5.5.0 (the
+    # direct pin) and chalk gets its own nested 5.3.0 copy.
+    ok, output = E2E.zap(project, "install", "--frozen-lockfile=false")
+    ok.should be_true, "diverged install failed: #{output}"
+    root_version = File.read(File.join(project, "node_modules", "supports-color", "package.json"))
+    JSON.parse(root_version)["version"].as_s.should eq("5.5.0")
+    nested = File.join(project, "node_modules", "chalk", "node_modules", "supports-color", "package.json")
+    File.exists?(nested).should be_true, "expected a nested supports-color@5.3.0 copy"
+    JSON.parse(File.read(nested))["version"].as_s.should eq("5.3.0")
+
+    # The one-shot dedupe collapses both onto 5.5.0.
+    ok, output = E2E.zap(project, "dedupe", "--frozen-lockfile=false")
+    ok.should be_true, "dedupe failed: #{output}"
+    lock = File.read(lock_path)
+    lock.should_not contain("supports-color@5.3.0")
+    lock.should contain("supports-color@5.5.0")
+    # The declared range survives in the root entry; the pins are exact.
+    lock.should contain("      supports-color: ^5.3.0\n    pinned_dependencies:")
+    lock.should contain("      supports-color: 5.5.0\n      escape-string-regexp: 1.0.5")
+    File.exists?(nested).should be_false, "nested 5.3.0 copy should be gone"
+    JSON.parse(File.read(File.join(project, "node_modules", "supports-color", "package.json")))["version"].as_s.should eq("5.5.0")
+
+    # A subsequent install is a no-op and leaves the lockfile byte-identical.
+    lock_after_dedupe = File.read(lock_path)
+    ok, output = E2E.zap(project, "install", "--frozen-lockfile=false")
+    ok.should be_true, "reinstall failed: #{output}"
+    output.should contain("up to date")
+    File.read(lock_path).should eq(lock_after_dedupe)
+  end
+end

--- a/spec/e2e/specs.cr
+++ b/spec/e2e/specs.cr
@@ -1,2 +1,3 @@
 require "./harness"
 require "./http"
+require "./dedupe"

--- a/specifications/README.md
+++ b/specifications/README.md
@@ -45,6 +45,7 @@ A readable example, rendered exactly like the real specs:
 - [Workspaces](workspaces.md) — monorepo support.
 - [Configuration](config.md) — the `zap` section and the npmrc.
 - [Catalogs](catalogs.md) — the `catalog:` protocol (pnpm / yarn parity).
+- [Dedupe](dedupe.md) — collapsing compatible resolutions (prefer-dedupe).
 
 ## The process: specification-first development
 

--- a/specifications/config.md
+++ b/specifications/config.md
@@ -11,7 +11,7 @@ registry access lives in the npmrc files.
   | Key | Type | Default | Meaning |
   | --- | --- | --- | --- |
   | `strategy` | enum | auto | `classic`, `classic_shallow`, `isolated`, `pnp` |
-  | `hoist_patterns`, `public_hoist_patterns` | string[] | built-in | classic hoisting |
+  | `hoist_patterns`, `public_hoist_patterns` | string[] | built-in | hoisting patterns (classic + isolated) |
   | `package_extensions` | map | `{}` | merge fields into matched packages |
   | `check_peer_dependencies` | bool | false | fail on unmet peers |
   | `patched_dependencies` | map | — | package selector to patch file |
@@ -27,12 +27,24 @@ registry access lives in the npmrc files.
   | `trust_policy` | string | off | `no-downgrade` |
   | `trust_policy_exclude` | string[] | — | names or `name@range` |
   | `named_registries` | map | — | alias to registry URL |
+  | `catalog`, `catalogs` | map | — | the catalog protocol (see [Catalogs](catalogs.md)) |
+  | `prefer_dedupe` | bool | true | reuse the highest already-used compatible version |
 
 - **Resolve the registries from the npmrc.** The default `registry`, the
   `@scope:registry` entries, and `strict_ssl` are shared by the resolution and
   the download phases ([data/npmrc.cr](../packages/data/npmrc.cr)
   `Data::Npmrc`, [install/registry_clients.cr](../packages/commands/install/registry_clients.cr)
   `RegistryClients`).
+
+- **Hoisting patterns come from the `zap` section only.** pnpm reads
+  `public-hoist-pattern`, `hoist-pattern` and `hoist` from the project
+  `.npmrc`; zap does not follow those keys. A repository configured for pnpm
+  should mirror them into `zap.public_hoist_patterns` /
+  `zap.hoist_patterns` (the defaults are `*` for `hoist_patterns` and
+  `*eslint*`, `*prettier*` for `public_hoist_patterns`). Packages matching
+  `public_hoist_patterns` are linked at the root `node_modules`, which is
+  what build tools and lifecycle scripts relying on hoisted types (e.g.
+  `@types/react`) resolve from.
 
 - **Write the `zap` section only through the commands that own it.** The
   save paths (`patch-commit`, `approve-builds`) edit the manifest in place and

--- a/specifications/dedupe.md
+++ b/specifications/dedupe.md
@@ -1,0 +1,125 @@
+# Dependency deduplication (prefer-dedupe)
+
+The resolution prefers to reuse a version already present in the
+dependency tree when the declared range is compatible, collapsing several
+compatible resolutions into a single one: the highest version in use.
+On by default; the `zap.prefer_dedupe` config (and the
+`ZAP_INSTALL_PREFER_DEDUPE` environment variable) controls it.
+
+## Prior art
+
+- **pnpm dedupes by default**: the lockfile keeps a single version when
+  the ranges are compatible, and a new dependency that an already-used
+  version satisfies reuses it instead of resolving a fresh one. pnpm's
+  `prefer-dedupe` makes the resolution prefer the versions already in the
+  lockfile even when a newer one satisfies the range.
+- **npm and yarn** hoist at the tree level but resolve each declared range
+  independently, so compatible-but-different versions coexist.
+
+## Current behavior
+
+The resolution reuses the lockfile only on an exact match: the declared
+range is turned into a key (`name@<range>`) and looked up in the lockfile
+packages. A range that no existing key matches resolves fresh from the
+registry, so two compatible ranges (`^1.2.0` and `~1.2.3`, or `^1.2.0`
+declared in two workspaces) can pin different versions even though one
+would satisfy both.
+
+## Dedupe semantics
+
+- Before fetching the registry metadata for a package, the resolver looks
+  at the versions of the same package already resolved in this install
+  (the lockfile entries and the in-flight resolutions of the current run).
+  If any satisfies the declared range, the highest such version is pinned
+  instead of resolving the range.
+- The dedupe applies to direct and transitive dependencies, across
+  workspaces and third-party subtrees.
+- The dedupe only triggers when a used version satisfies the range;
+  otherwise the normal resolution runs and pins a fresh version.
+- The candidates are the versions actually in use in the repo (the
+  lockfile plus the current run, across the root, the workspace members,
+  and third-party subtrees), not every version the registry offers: "when
+  there is at least 1 version already used in the repo, adding a dep
+  defaults to the higher version in use".
+- `zap add` inherits the dedupe when its requested range is compatible. An
+  explicit range remains the saved range; an unversioned add derives its
+  default saved range from the resolved version.
+
+## The option
+
+- `zap.prefer_dedupe: true` (default) in the package.json zap config,
+  overridable with the `ZAP_INSTALL_PREFER_DEDUPE` environment variable
+  (the install-config env pattern).
+- When false, every dependency resolves its declared range fresh, with
+  only the exact-key lockfile reuse (the current behavior).
+
+## Interactions
+
+- The lockfile pins stay authoritative: a fresh resolve keeps its version;
+  a reinstall reuses the pinned version.
+- Updates (`zap up`): the dedupe is skipped entirely during an update run
+  (including `--recursive` and `--latest`), because the re-resolutions are
+  deliberate and must not collapse back to the stale lockfile versions. A
+  subsequent plain install dedupes the updated tree.
+- Aliases and named registries: the dedupe applies within the same package
+  identity (same name and registry).
+- Peer dependencies: the dedupe must not violate the peer ranges (the peer
+  check runs after the resolution as today).
+
+## Edge cases
+
+- The highest used version is chosen among the candidates that satisfy
+  the range (a semver intersection).
+- The dedupe never downgrades: if no used version satisfies the range, the
+  resolution is unchanged.
+- A reused version is already pinned in the lockfile, so the
+  recently-published quarantine does not apply to it; the trust policy
+  still applies to fresh resolutions.
+- The dedupe and `--recursive` / `--latest` updates: the update run
+  re-resolves deliberately, so the dedupe stays skipped (see
+  Interactions); a subsequent plain install dedupes the updated tree.
+
+## One-shot command (`zap dedupe`)
+
+The resolution-level dedupe collapses compatible versions at install
+time, but a tree can still hold compatible-but-different versions
+(installed before the feature existed, or with the option off).
+`zap dedupe` is the one-shot pass: it re-resolves the whole tree with
+the prefer-dedupe preference and collapses those versions into the
+highest one in use.
+
+- No arguments. With `prefer_dedupe` enabled, it runs like a full
+  re-resolution of the tree (`zap up --recursive`) with dedupe active. With
+  the option off, it degrades to a plain install as described below.
+- The tree semantics stay identical: ranges are never rewritten, only
+  merged versions a shared one satisfies.
+- The lockfile records transitive dependencies as exact resolved
+  versions, so the pass re-fetches the parents' manifests
+  (force_metadata_retrieval) to recover the declared ranges: a
+  transitive divergence collapses too, not only the root and the
+  workspace members' package.json ranges.
+- With the classic strategy, the hoisting derives from the lockfile:
+  the writer removes a stale physical copy at a parent's own
+  node_modules as a byproduct of re-deriving the dependency's
+  placement (a copy is only valid while the dependency installs at the
+  parent's own level; when the hoist lands above it — e.g. a sibling
+  subtree now provides the version at a higher level — the copy is
+  obsolete). No tree crawl: the placement is known when it is computed.
+  A package hoisted below the root (when the root holds an incompatible
+  version) is handled the same way.
+
+- Physical cleanup is placement-aware. The classic writer removes a stale
+  copy at the direct parent's `node_modules` when the new hoist lands higher;
+  the remaining orphan sweep checks only root and workspace `node_modules`
+  entries against the persisted `.zap-state` path-to-lockfile-key map. It
+  does not recursively crawl every package's nested tree, and leaves paths
+  with no Zap state entry untouched.
+- It respects `zap.prefer_dedupe: false` and the
+  `ZAP_INSTALL_PREFER_DEDUPE=false` environment variable: with the
+  option off, `zap dedupe` degrades to a plain install — the lockfile
+  pins stay authoritative, nothing re-resolves or collapses (a no-op on
+  the versions), and the tree is not silently upgraded to the newest
+  registry versions.
+- npm's equivalent is `npm dedupe`, pnpm's is `pnpm dedupe`; both
+  re-resolve compatible ranges in the lockfile to a single version.
+


### PR DESCRIPTION
## Summary

Add pnpm-style `prefer-dedupe` resolution and the one-shot `zap dedupe` command. Compatible ranges reuse the highest already-used version by default, including transitive dependencies, workspace members, and third-party subtrees.

The branch also makes the full install path safe for the resulting lockfile and physical tree:

- direct and transitive candidate pins remain exact and aliases remain aliases;
- updates deliberately skip dedupe, while `prefer_dedupe: false` makes the one-shot pass a plain install;
- package extensions apply once per package per resolution pass;
- workspace dependents and lockfile roots remain complete across fresh re-resolution;
- classic hoisting removes stale nested copies from the placement decision instead of recursively crawling the tree;
- the top-level orphan sweep uses persisted `.zap-state` ownership data;
- git, catalog, file, alias, override, package-extension, partial-install, and all strategy paths are covered.

## Documentation

- `specifications/dedupe.md`
- `specifications/config.md`
- README command list

## Verification

- Commands specs: 403 examples, 0 failures
- Monorepo packages: 18/18
- End-to-end specs: 7/7
- Release build: successful
- CI: all 12 jobs green on the consolidated branch
- Real ledger-live verification: `zap dedupe`, frozen reinstall, unfrozen reinstall, `zap up`, and `--check-resolutions` pass; dedupe and reinstall lockfiles are byte-identical

Tracks #39.