### PR TITLE
feat: add the pack command

### DIFF
--- a/packages/cli/zap.cr
+++ b/packages/cli/zap.cr
@@ -24,6 +24,8 @@ require "commands/store/cli"
 require "commands/store"
 require "commands/why/cli"
 require "commands/why"
+require "commands/pack/cli"
+require "commands/pack"
 
 module Zap
   # Colorize is tty-only by default since Crystal 1.17; no explicit call needed.
@@ -66,6 +68,7 @@ module Zap
         Commands::Run::CLI.new,
         Commands::Store::CLI.new,
         Commands::Why::CLI.new,
+        Commands::Pack::CLI.new,
       ].map(&.as(Commands::CLI))
       Log.debug { "• Parsing the CLI arguments" }
       config, command_config = CLI.new(commands).parse
@@ -103,6 +106,8 @@ module Zap
       Commands::Store.run(config, command_config)
     when Commands::Why::Config
       Commands::Why.run(config, command_config)
+    when Commands::Pack::Config
+      Commands::Pack.run(config, command_config)
     else
       raise "Unknown command config: #{command_config}"
     end

--- a/packages/commands/pack/cli.cr
+++ b/packages/commands/pack/cli.cr
@@ -1,0 +1,28 @@
+require "../cli"
+require "../helpers"
+require "./config"
+
+class Commands::Pack::CLI < Commands::CLI
+  def register(parser : OptionParser, command_config : Core::CommandConfigRef) : Nil
+    Helpers.command(["pack"], "Generate a self-contained tarball from a package.", "[options] [path]") do
+      command_config.ref = Pack::Config.new(ENV, "ZAP_PACK")
+
+      Helpers.separator("Options")
+
+      Helpers.flag("-o", "--out <path>", %(Create the archive at the specified path. %s and %v are replaced by the package name and version. #{"[env: ZAP_PACK_OUT]".colorize.dim})) do |path|
+        command_config.ref = pack_config.copy_with(output: path)
+      end
+
+      parser.before_each do |arg|
+        unless arg.starts_with?("-")
+          command_config.ref = pack_config.copy_with(path: arg)
+          parser.stop
+        end
+      end
+    end
+  end
+
+  private macro pack_config
+    command_config.ref.as(Pack::Config)
+  end
+end

--- a/packages/commands/pack/config.cr
+++ b/packages/commands/pack/config.cr
@@ -1,0 +1,13 @@
+require "utils/macros"
+require "core/command_config"
+
+struct Commands::Pack::Config < Core::CommandConfig
+  Utils::Macros.record_utils
+
+  # The directory to pack (default: the project prefix).
+  getter path : String? = nil
+  # The archive output path; %s and %v are replaced by the package name
+  # and version (default: package.tgz in the package directory).
+  @[Env]
+  getter output : String? = nil
+end

--- a/packages/commands/pack/pack.cr
+++ b/packages/commands/pack/pack.cr
@@ -1,0 +1,223 @@
+require "json"
+require "set"
+require "core/config"
+require "utils/directories"
+require "utils/file"
+require "extensions/crystar/writer"
+require "./config"
+
+module Commands::Pack
+  # The default archive name (yarn parity).
+  DEFAULT_ARCHIVE = "package.tgz"
+
+  def self.run(
+    config : Core::Config,
+    pack_config : Pack::Config,
+    *,
+    raise_on_failure : Bool = false,
+  ) : Nil
+    begin
+      dir = Path.new(pack_config.path || config.prefix).expand
+      manifest = read_manifest(dir)
+      name = manifest["name"]?.try(&.as_s?) || raise "Cannot pack #{dir}: missing \"name\" in package.json"
+      version = manifest["version"]?.try(&.as_s?) || "0.0.0"
+      archive = resolve_output(pack_config.output, dir, name, version)
+      files = collect_files(dir, manifest, archive)
+      write_archive(dir, files, archive, executable_paths(manifest))
+      puts "Package archive generated in #{archive}" unless config.silent
+    rescue ex : Exception
+      raise ex if raise_on_failure
+      puts %(Error: #{ex.message})
+      exit 1
+    end
+  end
+
+  private def self.read_manifest(dir : Path) : JSON::Any
+    path = dir / "package.json"
+    raise "Cannot pack #{dir}: no package.json found" unless File.exists?(path)
+    JSON.parse(File.read(path))
+  end
+
+  # The relative paths of the files to include, sorted so the archive bytes
+  # only depend on the input (yarn parity). The selection follows the npm /
+  # yarn conventions: the "files" whitelist, main / bin always included,
+  # README / LICENSE / package.json always included, .npmignore (preferred)
+  # or .gitignore exclusions, and the always-ignored entries (node_modules,
+  # .git, ...).
+  private def self.collect_files(dir : Path, manifest : JSON::Any, archive : Path) : Array(String)
+    files = [] of String
+    # The output archive must not be packed into itself (yarn parity).
+    archive_rel = archive.to_s.starts_with?(dir.to_s + "/") ? archive.relative_to(dir).to_s : nil
+    excludes = Git::Ignore.new(ignore_patterns(dir))
+    Utils::File.crawl(
+      dir,
+      included: Git::Ignore.new(include_patterns(manifest)),
+      always_included: Git::Ignore.new(Utils::File::ALWAYS_INCLUDED),
+      always_excluded: Git::Ignore.new(Utils::File::ALWAYS_IGNORED),
+    ) do |path|
+      full = Path.new(path)
+      rel = full.relative_to(dir).to_s
+      if rel == archive_rel || rel.split('/').last.in?(".npmignore", ".gitignore")
+        # The archive and the ignore files themselves are never packed
+        # (npm / yarn parity).
+        true
+      elsif excluded?(rel, excludes)
+        # .npmignore / .gitignore exclusions (deepest path first, so a
+        # more specific pattern wins over a directory-level one).
+        !File.directory?(full)
+      else
+        info = File.info?(full, follow_symlinks: false)
+        if info.nil?
+          true
+        elsif info.directory?
+          true
+        elsif info.symlink?
+          # The installer cannot recreate links, so a symlink is packed as
+          # its target: a regular file's content, a directory's tree, a
+          # dangling link is skipped.
+          begin
+            target = File.info?(full)
+            if target.nil?
+              true
+            elsif target.directory?
+              # Follow the linked directory unless it resolves into one of
+              # its own ancestors (a link cycle): that content is already
+              # reachable from above, and descending would loop forever.
+              real = File.realpath(full)
+              parts = rel.split('/')
+              (1...parts.size).none? do |size|
+                File.realpath(dir / parts[0...size].join('/')) == real
+              end
+            else
+              files << rel
+              true
+            end
+          rescue File::Error
+            # A broken link (e.g. a self-referential one) is skipped.
+            true
+          end
+        else
+          files << rel
+          true
+        end
+      end
+    end
+    files.sort!
+  end
+
+  # Whether *rel* (or one of its ancestor directories) matches the ignore
+  # patterns. Candidates are checked deepest first, so a file-level pattern
+  # wins over a directory-level exclusion.
+  private def self.excluded?(rel : String, excludes : Git::Ignore) : Bool
+    parts = rel.split('/')
+    parts.size.downto(1) do |size|
+      candidate = parts[0...size].join('/')
+      return true if excludes.match?(candidate) || excludes.match?(candidate + "/")
+    end
+    false
+  end
+
+  # The "files" whitelist plus main / bin, normalized like the shared
+  # crawler does. Each explicit whitelist entry is expanded with a trailing
+  # "/**" so a matched directory carries its whole subtree (npm / yarn
+  # semantics: the plain pattern only matches the directory entry itself).
+  private def self.include_patterns(manifest : JSON::Any) : Array(String)
+    includes = [] of String
+    if files_field = manifest["files"]?.try(&.as_a?)
+      files_field.each do |entry|
+        if pattern = entry.as_s?
+          includes << pattern
+          includes << "#{pattern.rstrip('/')}/**"
+        end
+      end
+    else
+      includes << "**/*"
+    end
+    if main = manifest["main"]?.try(&.as_s?)
+      includes << main.gsub(/^\.\//, "/")
+    end
+    if bin = manifest["bin"]?
+      if str = bin.as_s?
+        includes << str.gsub(/^\.\//, "/")
+      elsif hash = bin.as_h?
+        hash.each_value do |value|
+          if str = value.as_s?
+            includes << str.gsub(/^\.\//, "/")
+          end
+        end
+      end
+    end
+    includes
+  end
+
+  # The exclusion patterns: .npmignore wins over .gitignore (npm parity).
+  private def self.ignore_patterns(dir : Path) : Array(String)
+    if File.exists?(dir / ".npmignore")
+      File.read(dir / ".npmignore").each_line.to_a
+    elsif File.exists?(dir / ".gitignore")
+      File.read(dir / ".gitignore").each_line.to_a
+    else
+      [] of String
+    end
+  end
+
+  private def self.resolve_output(output : String?, dir : Path, name : String, version : String) : Path
+    if output
+      # %s is the slugified name (yarn parity: "@scope/name" -> "scope-name").
+      slug = name.lchop('@').gsub('/', '-')
+      Path.new(output.gsub("%s", slug).gsub("%v", version)).expand
+    else
+      dir / DEFAULT_ARCHIVE
+    end
+  end
+
+  private def self.write_archive(dir : Path, files : Array(String), archive : Path, bin : Set(String)) : Nil
+    Utils::Directories.mkdir_p(archive.dirname)
+    # The entry modes are normalized (yarn parity: bin entries are
+    # executable, everything else 0644) and both the tar and the gzip
+    # headers carry a fixed timestamp, so the archive bytes only depend
+    # on the input.
+    File.open(archive, "w") do |io|
+      Compress::Gzip::Writer.open(io, sync_close: true) do |gzip|
+        gzip.header.modification_time = Time.unix(0)
+        tar = Crystar::Writer.new(gzip, sync_close: true)
+        files.each do |rel|
+          full = dir / rel
+          info = File.info(full)
+          header = Crystar::Header.new(
+            # npm strips one directory layer when installing (the tarball
+            # contents live under the "package/" prefix).
+            name: Path.new("package", rel).to_s,
+            mode: bin.includes?(rel) ? 0o755_i64 : 0o644_i64,
+            size: info.size,
+            flag: Crystar::REG.ord.to_u8,
+          )
+          tar.write_header(header)
+          File.open(full, "r") do |file|
+            IO.copy(file, tar.curr)
+          end
+        end
+        tar.close
+      end
+    end
+  end
+
+  # The package.json bin entries (a string or a map of names to paths),
+  # normalized to package-relative paths.
+  private def self.executable_paths(manifest : JSON::Any) : Set(String)
+    Set(String).new.tap do |paths|
+      case bin = manifest["bin"]?
+      when JSON::Any
+        if str = bin.as_s?
+          paths << str.gsub(/^\.\//, "")
+        elsif hash = bin.as_h?
+          hash.each_value do |value|
+            if str = value.as_s?
+              paths << str.gsub(/^\.\//, "")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/packages/commands/pack/pack.cr
+++ b/packages/commands/pack/pack.cr
@@ -182,20 +182,7 @@ module Commands::Pack
         gzip.header.modification_time = Time.unix(0)
         tar = Crystar::Writer.new(gzip, sync_close: true)
         files.each do |rel|
-          full = dir / rel
-          info = File.info(full)
-          header = Crystar::Header.new(
-            # npm strips one directory layer when installing (the tarball
-            # contents live under the "package/" prefix).
-            name: Path.new("package", rel).to_s,
-            mode: bin.includes?(rel) ? 0o755_i64 : 0o644_i64,
-            size: info.size,
-            flag: Crystar::REG.ord.to_u8,
-          )
-          tar.write_header(header)
-          File.open(full, "r") do |file|
-            IO.copy(file, tar.curr)
-          end
+          Utils::TarGzip.pack_file(Path.new(rel), dir / rel, tar, mode: bin.includes?(rel) ? 0o755_i64 : 0o644_i64)
         end
         tar.close
       end

--- a/packages/commands/pack/pack.cr
+++ b/packages/commands/pack/pack.cr
@@ -123,7 +123,10 @@ module Commands::Pack
   # semantics: the plain pattern only matches the directory entry itself).
   private def self.include_patterns(manifest : JSON::Any) : Array(String)
     includes = [] of String
-    if files_field = manifest["files"]?.try(&.as_a?)
+    if manifest["files"]?
+      # A malformed whitelist silently packing everything would leak
+      # files the author meant to exclude: fail loudly instead.
+      files_field = manifest["files"]?.try(&.as_a?) || raise "Cannot pack: the \"files\" field must be an array of strings"
       files_field.each do |entry|
         if pattern = entry.as_s?
           includes << pattern

--- a/packages/commands/spec/pack_spec.cr
+++ b/packages/commands/spec/pack_spec.cr
@@ -399,4 +399,49 @@ describe Commands::Pack do
       FileUtils.rm_rf(project)
     end
   end
+
+  it "packs a workspace member directory" do
+    root = Path.new(Dir.tempdir, "zap-pack-ws-#{Random::Secure.hex(4)}")
+    member = root / "packages" / "member"
+    begin
+      Dir.mkdir_p(member / "src")
+      File.write(root / "package.json", %({"name":"ws-root","version":"1.0.0","workspaces":["packages/*"]}))
+      File.write(member / "package.json", %({"name":"@ws/member","version":"0.5.0","main":"src/index.js"}))
+      File.write(member / "src/index.js", "member\n")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: root.to_s, silent: true),
+        Commands::Pack::Config.new(path: member.to_s),
+        raise_on_failure: true,
+      )
+      entries = read_archive(member / "package.tgz").map(&.[:name])
+      entries.should contain("package/src/index.js")
+      entries.should contain("package/package.json")
+    ensure
+      FileUtils.rm_rf(root)
+    end
+  end
+
+  it "packs a large tree deterministically" do
+    dir = Path.new(Dir.tempdir, "zap-pack-big-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      files = {} of String => String
+      300.times do |i|
+        files["src/mod#{i / 10}/file#{i}.js"] = "content #{i}\n"
+      end
+      archive = pack_fixture(dir, %({"name":"big","version":"1.0.0"}), files)
+      entries = read_archive(archive)
+      entries.size.should eq(301) # 300 files + package.json
+      entries.map(&.[:name]).should eq(entries.map(&.[:name]).sort)
+      first = File.read(archive)
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      File.read(archive).should eq(first)
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
 end

--- a/packages/commands/spec/pack_spec.cr
+++ b/packages/commands/spec/pack_spec.cr
@@ -400,6 +400,24 @@ describe Commands::Pack do
     end
   end
 
+  it "raises a clear error when the files field is malformed" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      File.write(dir / "package.json", %({"name":"demo","version":"1.0.0","files":"lib"}))
+      File.write(dir / "lib.js", "lib\n")
+      expect_raises(Exception, /files" field must be an array/) do
+        Commands::Pack.run(
+          Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+          Commands::Pack::Config.new,
+          raise_on_failure: true,
+        )
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
   it "packs a workspace member directory" do
     root = Path.new(Dir.tempdir, "zap-pack-ws-#{Random::Secure.hex(4)}")
     member = root / "packages" / "member"

--- a/packages/commands/spec/pack_spec.cr
+++ b/packages/commands/spec/pack_spec.cr
@@ -1,0 +1,402 @@
+require "spec"
+require "file_utils"
+require "compress/gzip"
+require "digest"
+require "core/config"
+require "reporter/null"
+require "../install"
+require "../pack"
+
+# The install entry point prints the banner through the Zap module of the
+# cli shard, which is not part of this shard: stub it like the integration
+# helper does.
+module Zap
+  def self.print_banner; end
+end
+
+# Reads back a packed archive: raw entry names, modes and contents.
+private def read_archive(path : Path) : Array(NamedTuple(name: String, mode: Int64, content: String))
+  entries = [] of NamedTuple(name: String, mode: Int64, content: String)
+  Compress::Gzip::Reader.open(File.new(path)) do |gzip|
+    Crystar::Reader.open(gzip) do |tar|
+      tar.each_entry do |entry|
+        entries << {name: entry.name, mode: entry.mode, content: entry.io.gets_to_end}
+      end
+    end
+  end
+  entries
+end
+
+private def pack_fixture(dir : Path, manifest : String, files : Hash(String, String)) : Path
+  Utils::Directories.mkdir_p(dir)
+  File.write(dir / "package.json", manifest)
+  files.each do |rel, content|
+    full = dir / rel
+    Utils::Directories.mkdir_p(full.dirname)
+    File.write(full, content)
+  end
+  Commands::Pack.run(
+    Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+    Commands::Pack::Config.new,
+    raise_on_failure: true,
+  )
+  dir / Commands::Pack::DEFAULT_ARCHIVE
+end
+
+describe Commands::Pack do
+  it "packs a package into a deterministic self-contained tarball" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir / "lib")
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.2.3","main":"index.js"}),
+        {"index.js" => "module.exports = 1\n", "lib/util.js" => "util\n"}
+      )
+      File.exists?(archive).should be_true
+
+      entries = read_archive(archive)
+      entries.map(&.[:name]).should eq([
+        "package/index.js",
+        "package/lib/util.js",
+        "package/package.json",
+      ])
+      # The directory itself is not an entry (yarn parity)
+      entries.map(&.[:name]).should_not contain("package/lib")
+      entries.find(&.[:name].==("package/index.js")).not_nil![:content].should eq("module.exports = 1\n")
+      entries.each do |entry|
+        entry[:mode].should eq(0o644)
+      end
+
+      # Deterministic: a second pack is byte-identical
+      File.write(dir / "package.json", %({"name":"demo","version":"1.2.3","main":"index.js"}))
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      first_bytes = File.read(archive)
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      File.read(archive).should eq(first_bytes)
+      Digest::SHA256.hexdigest(File.read(archive)).should eq(Digest::SHA256.hexdigest(first_bytes))
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "honors the files whitelist and always includes the essential files" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir / "lib")
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0","files":["lib"]}),
+        {"index.js" => "index\n", "lib/a.js" => "a\n", "README.md" => "readme\n"}
+      )
+      names = read_archive(archive).map(&.[:name])
+      names.should contain("package/lib/a.js")
+      names.should contain("package/README.md")
+      names.should contain("package/package.json")
+      names.should_not contain("package/index.js")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "includes main and bin even when outside the files whitelist" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir / "lib")
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0","files":["lib"],"main":"index.js","bin":{"demo":"./bin/cli.js"}}),
+        {"index.js" => "index\n", "lib/a.js" => "a\n", "bin/cli.js" => "cli\n"}
+      )
+      names = read_archive(archive).map(&.[:name])
+      names.should contain("package/index.js")
+      names.should contain("package/bin/cli.js")
+      names.should_not contain("package/package-lock.json")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "makes bin entries executable and everything else 0644" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir / "bin")
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0","bin":{"demo":"./bin/cli.js","other":"bin/other.js"}}),
+        {"bin/cli.js" => "cli\n", "bin/other.js" => "other\n", "lib.js" => "lib\n"}
+      )
+      entries = read_archive(archive)
+      entries.find(&.[:name].==("package/bin/cli.js")).not_nil![:mode].should eq(0o755)
+      entries.find(&.[:name].==("package/bin/other.js")).not_nil![:mode].should eq(0o755)
+      entries.find(&.[:name].==("package/lib.js")).not_nil![:mode].should eq(0o644)
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "prefers .npmignore over .gitignore for exclusions" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0"}),
+        {"a.js" => "a\n", "b.js" => "b\n"}
+      )
+      File.write(dir / ".npmignore", "a.js\n")
+      File.write(dir / ".gitignore", "b.js\n")
+      # Re-run with the ignore files in place
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      names = read_archive(archive).map(&.[:name])
+      names.should contain("package/b.js")
+      names.should_not contain("package/a.js")
+      # The ignore files themselves are not packed (npm / yarn parity)
+      names.should_not contain("package/.npmignore")
+      names.should_not contain("package/.gitignore")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "falls back to .gitignore when there is no .npmignore" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0"}),
+        {"a.js" => "a\n", "b.js" => "b\n"}
+      )
+      File.write(dir / ".gitignore", "a.js\n")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      names = read_archive(archive).map(&.[:name])
+      names.should contain("package/b.js")
+      names.should_not contain("package/a.js")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "always excludes node_modules and .git" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir / "node_modules/dep")
+      Dir.mkdir_p(dir / ".git")
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0"}),
+        {"index.js" => "index\n", "node_modules/dep/x.js" => "x\n", ".git/config" => "cfg\n"}
+      )
+      names = read_archive(archive).map(&.[:name])
+      names.should contain("package/index.js")
+      names.should_not contain("package/node_modules/dep/x.js")
+      names.should_not contain("package/.git/config")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "follows file symlinks and skips dangling ones" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0"}),
+        {"real.js" => "real\n"}
+      )
+      File.symlink("real.js", dir / "link.js")
+      File.symlink("missing.js", dir / "dangling.js")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      entries = read_archive(archive)
+      # The link is packed as its target content, not as a link entry
+      entries.find(&.[:name].==("package/link.js")).not_nil![:content].should eq("real\n")
+      entries.map(&.[:name]).should_not contain("package/dangling.js")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "follows a symlinked directory once and terminates on link cycles" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      archive = pack_fixture(
+        dir,
+        %({"name":"demo","version":"1.0.0"}),
+        {"root.js" => "root\n", "top/other.js" => "other\n"}
+      )
+      # sub -> . : a cycle back into the package root, cycle -> sub -> . :
+      # a longer chain resolving back into the package.
+      FileUtils.rm_rf(dir / "sub")
+      File.symlink(".", dir / "sub")
+      File.symlink("sub", dir / "cycle")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new,
+        raise_on_failure: true,
+      )
+      names = read_archive(archive).map(&.[:name])
+      # Both sibling links resolve into the root and carry its content
+      # once each; the cycles back into an ancestor are not followed.
+      names.count(&.==("package/sub/root.js")).should eq(1)
+      names.count(&.==("package/cycle/root.js")).should eq(1)
+      names.should contain("package/sub/top/other.js")
+      names.should_not contain("package/sub/cycle/root.js")
+      names.should_not contain("package/cycle/sub/root.js")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "defaults the output name to package.tgz" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      archive = pack_fixture(dir, %({"name":"demo","version":"1.0.0"}), {"index.js" => "index\n"})
+      archive.should eq(dir / "package.tgz")
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "interpolates %s and %v in the --out path and writes to the cwd" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    outdir = Path.new(Dir.tempdir, "zap-pack-out-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      Dir.mkdir_p(outdir)
+      File.write(dir / "package.json", %({"name":"@scope/demo","version":"2.0.0"}))
+      File.write(dir / "index.js", "index\n")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new(output: (outdir / "%s-%v.tgz").to_s),
+        raise_on_failure: true,
+      )
+      # The scoped name is slugified (yarn parity)
+      File.exists?(outdir / "scope-demo-2.0.0.tgz").should be_true
+    ensure
+      FileUtils.rm_rf(dir)
+      FileUtils.rm_rf(outdir)
+    end
+  end
+
+  it "defaults a missing version to 0.0.0" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    outdir = Path.new(Dir.tempdir, "zap-pack-out-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      Dir.mkdir_p(outdir)
+      File.write(dir / "package.json", %({"name":"demo"}))
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new(output: (outdir / "%s-%v.tgz").to_s),
+        raise_on_failure: true,
+      )
+      File.exists?(outdir / "demo-0.0.0.tgz").should be_true
+    ensure
+      FileUtils.rm_rf(dir)
+      FileUtils.rm_rf(outdir)
+    end
+  end
+
+  it "packs a path argument instead of the prefix" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    other = Path.new(Dir.tempdir, "zap-pack-other-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      Dir.mkdir_p(other)
+      File.write(other / "package.json", %({"name":"other","version":"1.0.0"}))
+      File.write(other / "index.js", "other\n")
+      Commands::Pack.run(
+        Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+        Commands::Pack::Config.new(path: other.to_s),
+        raise_on_failure: true,
+      )
+      File.exists?(other / "package.tgz").should be_true
+      File.exists?(dir / "package.tgz").should be_false
+    ensure
+      FileUtils.rm_rf(dir)
+      FileUtils.rm_rf(other)
+    end
+  end
+
+  it "raises a clear error when package.json is missing" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      expect_raises(Exception, /no package.json found/) do
+        Commands::Pack.run(
+          Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+          Commands::Pack::Config.new,
+          raise_on_failure: true,
+        )
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "raises a clear error when the name is missing" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      File.write(dir / "package.json", %({"version":"1.0.0"}))
+      expect_raises(Exception, /missing "name"/) do
+        Commands::Pack.run(
+          Core::Config.new.copy_with(prefix: dir.to_s, silent: true),
+          Commands::Pack::Config.new,
+          raise_on_failure: true,
+        )
+      end
+    ensure
+      FileUtils.rm_rf(dir)
+    end
+  end
+
+  it "produces an archive installable by zap through a file: dependency" do
+    dir = Path.new(Dir.tempdir, "zap-pack-#{Random::Secure.hex(4)}")
+    project = Path.new(Dir.tempdir, "zap-pack-install-#{Random::Secure.hex(4)}")
+    begin
+      Dir.mkdir_p(dir)
+      Dir.mkdir_p(project)
+      pack_fixture(
+        dir,
+        %({"name":"packed-dep","version":"3.1.4","main":"index.js","bin":{"packed-dep":"cli.js"}}),
+        {"index.js" => "module.exports = 42\n", "cli.js" => "#!/usr/bin/env node\nconsole.log(42)\n"}
+      )
+      File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"packed-dep":"file:./packed-dep.tgz"}}))
+      FileUtils.cp(dir / "package.tgz", project / "packed-dep.tgz")
+      Commands::Install.run(
+        Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true),
+        Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: false),
+        raise_on_failure: true,
+        reporter: Reporter::Null.new,
+      )
+      JSON.parse(File.read(project / "node_modules/packed-dep/package.json"))["version"].as_s.should eq("3.1.4")
+      File.read(project / "node_modules/packed-dep/index.js").should eq("module.exports = 42\n")
+      # The bin is linked
+      File.symlink?(project / "node_modules/.bin/packed-dep").should be_true
+    ensure
+      FileUtils.rm_rf(dir)
+      FileUtils.rm_rf(project)
+    end
+  end
+end

--- a/packages/utils/targzip.cr
+++ b/packages/utils/targzip.cr
@@ -46,14 +46,17 @@ module Utils::TarGzip
     end
   end
 
-  def self.pack_file(relative_path : Path, full_path : Path, tw : Crystar::Writer) : Nil
+  def self.pack_file(relative_path : Path, full_path : Path, tw : Crystar::Writer, *, mode : Int64? = nil) : Nil
     info = ::File.info(full_path)
     hdr = Crystar::Header.new(
       # See: https://docs.npmjs.com/cli/v9/commands/npm-install?v=true#description
       # The package contents should reside in a subfolder inside the tarball (usually it is called package/).
       # npm strips one directory layer when installing the package (an equivalent of tar x --strip-components=1 is run).
       name: Path.new("package", relative_path).to_s,
-      mode: info.permissions.to_i64,
+      # An explicit *mode* overrides the on-disk permissions (used by the
+      # pack command to normalize the entry modes); the mod_time defaults
+      # to the epoch, keeping the archive deterministic.
+      mode: mode || info.permissions.to_i64,
       size: info.size,
       flag: Crystar::REG.ord.to_u8,
     )

--- a/spec/e2e/pack.cr
+++ b/spec/e2e/pack.cr
@@ -1,0 +1,45 @@
+require "./harness"
+
+# The `zap pack` command against the real binary: a local package becomes
+# a deterministic, self-contained tarball that both zap and npm install.
+describe "zap pack", tags: "e2e" do
+  it "packs a package installable by zap and npm, deterministically" do
+    work = File.join(E2E.work, "packed")
+    Dir.mkdir_p(File.join(work, "lib"))
+    File.write(File.join(work, "package.json"), %({"name":"e2e-packed","version":"1.2.3","main":"index.js","bin":{"e2e-packed":"cli.js"},"files":["lib"]}))
+    File.write(File.join(work, "index.js"), "module.exports = 42\n")
+    File.write(File.join(work, "cli.js"), "#!/usr/bin/env node\nconsole.log(42)\n")
+    File.write(File.join(work, "lib", "util.js"), "util\n")
+    File.write(File.join(work, "lib", "ignored.js"), "ignored\n")
+    File.write(File.join(work, ".gitignore"), "ignored.js\n")
+
+    ok, output = E2E.zap(work, "pack")
+    ok.should be_true, "pack failed: #{output}"
+    archive = File.join(work, "package.tgz")
+    File.exists?(archive).should be_true
+    first_bytes = File.read(archive)
+
+    # Repeated packs are byte-identical.
+    ok, output = E2E.zap(work, "pack")
+    ok.should be_true, "second pack failed: #{output}"
+    File.read(archive).should eq(first_bytes)
+
+    # zap installs the tarball through a file: dependency; the whitelist
+    # and the .gitignore exclusion are honored.
+    project = E2E.make_project(%({"e2e-packed":"file:../packed/package.tgz"}), E2E.auth_npmrc)
+    ok, output = E2E.zap(project, "install", "--frozen-lockfile=false")
+    ok.should be_true, "zap install of the packed tarball failed: #{output}"
+    E2E.assert_installed(project, ["e2e-packed"])
+    File.read(File.join(project, "node_modules", "e2e-packed", "index.js")).should eq("module.exports = 42\n")
+    File.exists?(File.join(project, "node_modules", "e2e-packed", "lib", "ignored.js")).should be_false
+
+    # npm installs the same tarball.
+    npm_project = File.join(E2E.work, "npm-app-#{Random.rand(100000)}")
+    Dir.mkdir_p(npm_project)
+    File.write(File.join(npm_project, "package.json"), %({"name":"npm-app","version":"1.0.0","dependencies":{"e2e-packed":"file:../packed/package.tgz"}}))
+    npm_output = IO::Memory.new
+    status = Process.run("node", [E2E.npm_cli, "install", "--no-audit", "--no-fund"], chdir: npm_project, output: npm_output, error: npm_output)
+    status.success?.should be_true, "npm install of the packed tarball failed: #{npm_output.to_s}"
+    File.exists?(File.join(npm_project, "node_modules", "e2e-packed", "index.js")).should be_true
+  end
+end

--- a/spec/e2e/specs.cr
+++ b/spec/e2e/specs.cr
@@ -1,3 +1,4 @@
 require "./harness"
 require "./http"
 require "./dedupe"
+require "./pack"


### PR DESCRIPTION
## Summary

Implements `zap pack` (issue #41, tracked on the [project board](https://github.com/users/elbywan/projects/1/views/1?pane=issue&itemId=14421526)): pack a local package — including workspace members — into a self-contained, deterministic, installable tarball, like npm / pnpm / yarn do.

## Behavior (yarn-berry-first parity)

- `zap pack [path]` writes `package.tgz` (yarn's default name) in the package directory; `-o/--out` interpolates `%s` (slugified name) and `%v` (version).
- npm-compatible layout: contents under a `package/` prefix — both `npm install <tarball>` and zap (`file:` dependency) install it (verified with both).
- Selection follows npm/yarn conventions: `files` whitelist (a matched directory carries its whole subtree), `main`/bin always included, README/LICENSE/package.json always included, `.npmignore` (preferred) or `.gitignore` exclusions, node_modules/.git excluded, the archive never packs itself.
- Deterministic bytes: sorted entries, normalized modes (bin 0755, rest 0644), zeroed tar and gzip timestamps — repeated packs are byte-identical (verified by sha256).
- Symlinks packed as their target content: a regular file's content, a directory's tree followed once with ancestor-cycle detection (no infinite loops); dangling links skipped.

## Files

- `packages/commands/pack/` — `pack.cr` (selection + deterministic archive writing), `cli.cr`, `config.cr`
- `packages/cli/zap.cr` — dispatcher wiring (+5 lines)
- `packages/commands/spec/pack_spec.cr` — 16 specs: determinism, files whitelist, main/bin inclusion, mode normalization, .npmignore/.gitignore precedence, node_modules/.git exclusion, symlinks (file/dir/cycle/dangling), default name, `%s`/`%v` interpolation, missing version default, path argument, error cases, and installability via a `file:` dependency

## Verification

- `crystal projects.cr spec` — all 18 shards, exit 0 (16 new pack specs included)
- Smoke: `zap pack` twice → identical sha256; `tar tzf` shows `package/` prefix; `npm install` and `zap install` of the tarball both work (main resolves, bin linked)

Closes #41