### PR TITLE
fix: omit-aware prefer-dedupe and quiet broken-pipe exits

### DIFF
--- a/packages/cli/zap.cr
+++ b/packages/cli/zap.cr
@@ -72,6 +72,11 @@ module Zap
       ].map(&.as(Commands::CLI))
       Log.debug { "• Parsing the CLI arguments" }
       config, command_config = CLI.new(commands).parse
+    rescue e : IO::Error
+      # A consumer that closed the pipe early (zap ... | head) is not an
+      # error: exit quietly, like a SIGPIPE death would have.
+      exit 141 if e.os_error == Errno::EPIPE
+      raise e
     rescue e
       puts e.message
       exit Shared::Constants::ErrorCodes::EARLY_EXIT.to_i32
@@ -114,5 +119,10 @@ module Zap
 
     # Release the registry client pools (no-op when no install ran)
     Commands::Install::RegistryClients.close
+  rescue e : IO::Error
+    # A consumer that closed the pipe early (zap ... | head) is not an
+    # error: exit quietly, like a SIGPIPE death would have.
+    exit 141 if e.os_error == Errno::EPIPE
+    raise e
   end
 end

--- a/packages/commands/install/install.cr
+++ b/packages/commands/install/install.cr
@@ -128,6 +128,11 @@ module Commands::Install
         state = Commands::Install::Interactive.run(state)
       end
 
+      # Omit-aware prefer-dedupe: compute the reachable set from the
+      # pre-existing lockfile before the resolution pipeline starts (it
+      # must not see the current run's resolutions).
+      Resolver.reachable_packages(state, state.reachable_packages) if state.install_config.omit.size > 0
+
       # Resolve all dependencies
       update_changed = resolve_dependencies(state)
 

--- a/packages/commands/install/protocol/registry/resolver.cr
+++ b/packages/commands/install/protocol/registry/resolver.cr
@@ -76,10 +76,15 @@ struct Commands::Install::Protocol::Registry::Resolver < Commands::Install::Prot
   def dedupe_candidate(name : String, declared_range : String) : Data::Package?
     range = Semver.parse?(declared_range)
     return nil unless range
+    omit = state.install_config.omit
     best = nil
     # The name index keeps the scan to this package's entries instead of
     # the whole lockfile (O(entries) per dependency, not O(packages)).
     state.lockfile.packages_named(name).each do |pkg|
+      # With --omit, only the versions reachable from the installed roots
+      # are candidates: a version locked solely through an omitted
+      # dev/optional dependency is not in use.
+      next if !omit.empty? && !state.reachable_packages.includes?(pkg.key)
       next unless pkg.kind.registry?
       dist = pkg.dist
       # The tarball must come from the same registry base (the trailing

--- a/packages/commands/install/resolver.cr
+++ b/packages/commands/install/resolver.cr
@@ -92,6 +92,40 @@ module Commands::Install::Resolver
     changed
   end
 
+  # The lockfile keys reachable from the non-omitted roots — the packages
+  # that will actually be installed. With --omit, prefer-dedupe must not
+  # collapse onto versions that only exist in the lockfile through omitted
+  # dev/optional dependencies (the lockfile keeps the full graph, pnpm
+  # parity), so the candidate scan is filtered to this set. Computed once
+  # per install, before the resolution pipeline starts; nil when nothing
+  # is omitted (the filter is then a no-op and costs nothing).
+  def self.reachable_packages(state : Commands::Install::State, reachable : Concurrency::SafeSet(String)) : Nil
+    omit = state.install_config.omit
+    return if omit.empty?
+    omit_dev = omit.includes?(Config::Omit::Dev)
+    omit_optional = omit.includes?(Config::Omit::Optional)
+
+    queue = Deque(String).new
+    state.lockfile.roots.each_value do |root|
+      root.each_dependency(include_dev: !omit_dev, include_optional: !omit_optional) do |name, specifier, _|
+        key = specifier.is_a?(Data::Package::Alias) ? specifier.key : "#{name}@#{specifier}"
+        if reachable.add?(key)
+          queue << key
+        end
+      end
+    end
+    while key = queue.shift?
+      pkg = state.lockfile.packages[key]?
+      next unless pkg
+      pkg.each_dependency(include_dev: false, include_optional: !omit_optional) do |name, specifier, _|
+        child_key = specifier.is_a?(Data::Package::Alias) ? specifier.key : "#{name}@#{specifier}"
+        if reachable.add?(child_key)
+          queue << child_key
+        end
+      end
+    end
+  end
+
   # Whether the install is an update run (any re-resolution is
   # deliberate and must not be deduplicated against the stale lockfile).
   private def self.update_in_progress(config : Commands::Install::Config) : Bool

--- a/packages/commands/install/state.cr
+++ b/packages/commands/install/state.cr
@@ -32,5 +32,10 @@ module Commands::Install
     # this run; guards the recursive dependency crawl against infinite loops
     # (a fresh object is used for the metadata on every visit, so the flag
     # cannot live on the package itself).
-    resolved_keys : Concurrency::SafeSet(String) = Concurrency::SafeSet(String).new
+    resolved_keys : Concurrency::SafeSet(String) = Concurrency::SafeSet(String).new,
+    # Lockfile keys reachable from the non-omitted roots, for the
+    # omit-aware prefer-dedupe filter. Filled once, before the resolution
+    # pipeline starts, only when --omit is active; the candidate scan
+    # consults it only then.
+    reachable_packages : Concurrency::SafeSet(String) = Concurrency::SafeSet(String).new
 end

--- a/packages/commands/spec/install/integration/dedupe._spec.cr
+++ b/packages/commands/spec/install/integration/dedupe._spec.cr
@@ -590,6 +590,32 @@ describe "dedupe corner cases", tags: "integration" do
     end
   end
 
+  it "does not dedupe onto versions locked only by omitted dependencies" do
+    It.with_registry do |registry|
+      registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})
+      registry.add("dep", "1.2.0", It.pkg("dep", "1.2.0"), {"index.js" => "1.2.0"})
+      registry.add("a", "1.0.0", It.pkg("a", "1.0.0", dependencies: {"dep" => "^1.0.0"}), {"index.js" => "a"})
+      registry.add("b", "1.0.0", It.pkg("b", "1.0.0", dependencies: {"dep" => "1.0.0"}), {"index.js" => "b"})
+      project = Path.new(Dir.tempdir, "zap-dedupe-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(project)
+        File.write(project / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"a":"1.0.0"},"devDependencies":{"b":"1.0.0"}}))
+        File.write(project / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: project.to_s, store_path: (project / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, save: true, omit: [Commands::Install::Config::Omit::Dev])
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        # a's ^1.0.0 must resolve fresh to the highest version: the locked
+        # dep@1.0.0 is reachable only through the omitted dev edge and is
+        # not a prefer-dedupe candidate.
+        JSON.parse(File.read(project / "node_modules/dep/package.json"))["version"].as_s.should eq("1.2.0")
+        # The lockfile still keeps the full graph.
+        Data::Lockfile.new(project).packages.keys.select { |k| k.starts_with?("dep@") }.sort.should eq(["dep@1.0.0", "dep@1.2.0"])
+      ensure
+        FileUtils.rm_rf(project)
+      end
+    end
+  end
+
   it "keeps declared ranges in the lockfile root through the one-shot dedupe pass" do
     It.with_registry do |registry|
       registry.add("dep", "1.0.0", It.pkg("dep", "1.0.0"), {"index.js" => "1.0.0"})

--- a/packages/commands/spec/install/integration/spec_helper.cr
+++ b/packages/commands/spec/install/integration/spec_helper.cr
@@ -19,6 +19,14 @@ module Zap
   def self.print_banner; end
 end
 
+# The in-process installs never run the CLI epilogue that closes the
+# global registry client pools (Zap.run does it after a real command):
+# close them once the suite is done, so no persistent HTTP/2 connection
+# or its reconnect fiber outlives the process.
+Spec.after_suite do
+  Commands::Install::RegistryClients.close
+end
+
 alias It = Zap::Integration
 
 module Zap::Integration


### PR DESCRIPTION
## Summary

Two fixes on top of the pack work, plus spec-suite hygiene:

### 1. Omit-aware prefer-dedupe (`31bb0ca` → `eeafd11`)

With `--omit`, the lockfile keeps the full graph (pnpm parity), but `prefer_dedupe` collapsed a dependency onto versions locked *only* through the omitted dev/optional subtrees — picking e.g. a dev-only `1.0.0` for a prod `^1.0.0`, depending on the resolution order. This made `dedupe._spec.cr` "dedupes with dev dependencies omitted" flaky (~1/5–1/6 runs).

The dedupe candidate scan is now filtered to the packages reachable from the non-omitted roots: a one-time BFS over the pre-existing lockfile, computed before the resolution pipeline starts. **Zero cost when `--omit` is not active** (the filter is skipped entirely). The previously flaky spec is now deterministic, plus a new contract spec.

### 2. Quiet exit when the output pipe closes (`17df28c`)

`zap ... | head -1` printed an `IO::Error: Broken pipe` backtrace once the reader went away (the runtime turns the EPIPE write into an exception). The CLI now exits `141` silently — the Unix convention — on both the parse and command phases. (Investigation note: the spec-suite "abnormal termination" was traced to an external SIGKILL in this dev environment, not a zap bug — no code fix exists for SIGKILL.)

### 3. Spec hygiene (`78d0a16`)

`Spec.after_suite` closes the global `RegistryClients` pools that in-process installs never close (the CLI epilogue does it in `Zap.run`).

## Verification

- `crystal projects.cr spec` — EXIT 0 (all shards; 48 pack+dedupe specs green, incl. the previously flaky one ×5)
- `zap --help | head -1` → exit 141, silent
- Full CI runs on macOS / Ubuntu / Windows