### PR TITLE
ci: bump GitHub actions to current majors

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -60,7 +60,7 @@ jobs:
         run: ./bench-local.sh
 
       - name: Upload benchmark artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-15-intel
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         run: brew update && brew install crystal || true
       - name: Copy static libraries
@@ -36,7 +36,7 @@ jobs:
           mkdir bin
           mv ./packages/cli/bin/zap ./bin/zap
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap_x86_64-apple-darwin
           path: ./bin/zap
@@ -45,7 +45,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         run: brew update && brew install crystal || true
       - name: Copy static libraries
@@ -69,7 +69,7 @@ jobs:
           mkdir bin
           mv ./packages/cli/bin/zap ./bin/zap
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap_arm64-apple-darwin
           path: ./bin/zap
@@ -80,7 +80,7 @@ jobs:
       image: crystallang/crystal:latest-alpine
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install dependencies
         run: |
           apk del openssl-dev openssl-libs-static
@@ -91,7 +91,7 @@ jobs:
           mkdir bin
           mv ./packages/cli/bin/zap ./bin/zap
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap_x86_64-linux-musl
           path: ./bin/zap
@@ -100,7 +100,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Build the binary
@@ -111,7 +111,7 @@ jobs:
           mv ./packages/cli/bin/zap.exe ./bin/zap.exe
           ls -al ./bin
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zap_x86_64-pc-win32.exe
           path: ${{ github.workspace }}\bin\zap.exe
@@ -122,7 +122,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
       - name: Check if release is needed
@@ -130,7 +130,7 @@ jobs:
           needs_release=$(git diff HEAD^1 shard.yml | grep "+version: " | wc -l | xargs)
           echo "needs_release=$needs_release" >> $GITHUB_ENV
       - name: Determine release version and tag
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         id: release-data
         if: ${{ env.needs_release == 1 }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: latest
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Install dependencies
@@ -27,11 +27,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
       - name: Install dependencies


### PR DESCRIPTION
Bumps the four Node-20-based actions to their current majors, removing the deprecation warnings on every run:

- actions/checkout v4 -> v7
- actions/upload-artifact v4 -> v7
- actions/setup-node v4 -> v7
- actions/github-script v6 -> v9

No input changes required (the workflows only use stable inputs: `fetch-depth`, `name`/`path`/`if-no-files-found`, `node-version`/`registry-url`, `script`). The Build/Tests checks on this PR validate the bumps.