### PR TITLE
perf: install optimizations (fast path, caches, concurrency)

### DIFF
--- a/bench/bench.sh
+++ b/bench/bench.sh
@@ -25,7 +25,10 @@ COMMANDS=(
   "env YARN_ENABLE_SCRIPTS=false YARN_ENABLE_IMMUTABLE_INSTALLS=false YARN_NODE_LINKER=node-modules $YARN"
   "$PNPM i --ignore-scripts"
   "$BUN i --ignore-scripts"
-  'zap i --ignore-scripts --frozen-lockfile=false'
+  # --check-resolutions=false: the flag defaults to on under CI, which
+  # disables the up-to-date fast path; the benchmark measures the local
+  # (default) behavior.
+  'zap i --ignore-scripts --frozen-lockfile=false --check-resolutions=false'
 )
 
 hyperfine --warmup 1 --runs 3 --export-json cold.json --prepare "$PREPARE_COLD" "${COMMANDS[@]}"

--- a/packages/commands/install/config.cr
+++ b/packages/commands/install/config.cr
@@ -77,10 +77,14 @@ struct Commands::Install::Config < Core::CommandConfig
   # the prefer-dedupe preference to collapse compatible versions already
   # pinned in the lockfile. Command-only, no env var.
   getter dedupe : Bool = false
-  # Single-threaded by default: fetches run in the caller's fiber, so extra
-  # pipeline threads only add overhead (measured ~30% slower cold installs).
-  # Bump with --workers / ZAP_WORKERS when more parallelism pays off.
-  getter workers : Int32 = ENV["ZAP_WORKERS"]?.try(&.to_i?) || 1
+  # A modest number of worker threads by default: the CPU-bound work
+  # (metadata decode, tarball extraction) parallelizes across packages -
+  # measured ~30-35% faster cold installs at 4-8 workers on a 12-thread
+  # machine. The historical "~30% slower" figure predates the current
+  # scheduler. Half the logical cores (the physical cores on
+  # hyperthreaded machines) capped at 4 balances the gain with memory and
+  # race exposure; override with --workers / ZAP_WORKERS.
+  getter workers : Int32 = ENV["ZAP_WORKERS"]?.try(&.to_i?) || Math.min(4, Math.max(1, System.cpu_count // 2))
   # When set, resolution errors raise instead of exiting the process
   # (used by the integration test suite)
   getter raise_on_failure : Bool = false

--- a/packages/commands/install/install.cr
+++ b/packages/commands/install/install.cr
@@ -1,4 +1,5 @@
 require "benchmark"
+require "digest/sha256"
 require "log"
 require "concurrency/pipeline"
 require "reporter/reporter"
@@ -128,6 +129,19 @@ module Commands::Install
         state = Commands::Install::Interactive.run(state)
       end
 
+      # Up-to-date fast path (issue #48): when nothing relevant changed
+      # since the last completed install — the package.json files, the
+      # .npmrc, the strategy, the omit set, the lockfile format, the patch
+      # files and the installed state — skip the resolution, download and
+      # linking passes entirely. The root project's own lifecycle scripts
+      # still run (npm/yarn parity); a requested --check-resolutions
+      # disables the fast path (its ref walk needs a full resolution).
+      if up_to_date?(state)
+        state.reporter.info("Dependencies are up to date — nothing to install.")
+        run_own_install_hooks(state)
+        next
+      end
+
       # Omit-aware prefer-dedupe: compute the reachable set from the
       # pre-existing lockfile before the resolution pipeline starts (it
       # must not see the current run's resolutions).
@@ -205,6 +219,9 @@ module Commands::Install
       # Persist the installed state (keys + applied patch hashes) after the
       # linking, so the freshly installed packages are recorded.
       Backend::InstalledState.save(state.installed_state_path, state.installed_state)
+      # Record the project fingerprint, the basis of the up-to-date fast
+      # path on the next install.
+      ::File.write(fingerprint_path(state), project_fingerprint(state))
     end
 
     # Print the report
@@ -239,6 +256,95 @@ module Commands::Install
       end
     end
     {realtime, memory}
+  end
+
+  # The file recording the project fingerprint, next to the installed
+  # state at the node_modules root (gitignored by convention, like the
+  # state file itself).
+  FINGERPRINT_FILE_NAME = ".zap-fingerprint"
+  FINGERPRINT_FORMAT    = "zap-install-fingerprint-v1"
+
+  private def self.fingerprint_path(state : State) : Path
+    Path.new(state.config.node_modules) / FINGERPRINT_FILE_NAME
+  end
+
+  # A SHA-256 over everything that can change the resolved tree: the
+  # package.json contents of the install scope (main package + workspaces),
+  # the project .npmrc, the install strategy, the omit set, the lockfile
+  # format, the configured patch files and the installed-state file.
+  # Hoisting / package-extensions / patched-dependencies option changes are
+  # already handled by their dedicated lockfile shasum checks, which force
+  # a re-install before this check runs.
+  private def self.project_fingerprint(state : State) : String
+    digest = Digest::SHA256.new
+    digest.update(FINGERPRINT_FORMAT)
+    digest.update(state.install_config.strategy.to_s)
+    digest.update(state.config.lockfile_format.to_s)
+    state.install_config.omit.map(&.to_s).sort.each do |omit|
+      digest.update("omit:")
+      digest.update(omit)
+    end
+    state.context.scope_packages_and_paths(:install).map { |(_, path)| path.to_s }.uniq!.sort!.each do |path|
+      digest.update(path)
+      digest.update(::File.read(Path.new(path) / "package.json"))
+    end
+    npmrc_path = Path.new(state.config.prefix) / ".npmrc"
+    digest.update(::File.read(npmrc_path)) if ::File.exists?(npmrc_path)
+    # The lockfile itself: a tampered or manually edited lockfile must
+    # trigger a full install (which re-resolves and repairs the tree)
+    # instead of silently keeping the old one. The file existence is
+    # checked directly: the loaded lockfile's read status reflects the
+    # initial load, which is stale once the resolution wrote it.
+    if ::File.exists?(state.lockfile.lockfile_path)
+      digest.update("lockfile:")
+      digest.update(::File.read(state.lockfile.lockfile_path))
+    end
+    # The configured patch files: a content change re-applies the patches
+    # (the patched_dependencies keys themselves live in package.json).
+    if patches = state.context.main_package.zap_config.try(&.patched_dependencies)
+      patches.values.sort.each do |patch_file|
+        digest.update("patch:")
+        digest.update(patch_file)
+        patch_path = Path.new(patch_file).expand(Path.new(state.config.prefix))
+        digest.update(::File.read(patch_path)) if ::File.exists?(patch_path)
+      end
+    end
+    # The installed-state file: an edited or stale record (e.g. a manual
+    # tampering) must trigger a full install, which prunes and repairs.
+    if ::File.exists?(state.installed_state_path)
+      digest.update("state:")
+      digest.update(::File.read(state.installed_state_path))
+    end
+    digest.final.hexstring
+  end
+
+  # Whether the previous install is still up to date: the lockfile exists,
+  # no change intent or forced refresh is requested, the recorded
+  # fingerprint matches the current one, and every recorded install path
+  # still exists (a partially deleted node_modules is repaired by a full
+  # install).
+  private def self.up_to_date?(state : State) : Bool
+    install_config = state.install_config
+    return false if install_config.refresh_install
+    return false if install_config.force_metadata_retrieval
+    return false if install_config.interactive
+    return false if install_config.dedupe
+    return false if install_config.update_all || install_config.update_latest || install_config.update_recursive
+    return false if install_config.added_packages.size > 0 || install_config.removed_packages.size > 0 || install_config.updated_packages.size > 0
+    # The lockfile verification walks the resolution refs, which only a
+    # full resolution populates: a requested check disables the fast path.
+    return false if install_config.check_resolutions
+    return false unless state.lockfile.read_status.from_disk?
+    return false unless ::File.exists?(state.installed_state_path)
+    fingerprint_path = self.fingerprint_path(state)
+    return false unless ::File.exists?(fingerprint_path)
+    return false unless ::File.read(fingerprint_path) == project_fingerprint(state)
+    # One stat per recorded install path: a missing entry means the tree
+    # was partially deleted and must be rebuilt (relocation repair).
+    state.installed_state.each_key do |path|
+      return false unless Dir.exists?(path)
+    end
+    true
   end
 
   private def self.print_info(

--- a/packages/commands/install/linker/classic/writer/registry.cr
+++ b/packages/commands/install/linker/classic/writer/registry.cr
@@ -130,14 +130,14 @@ class Commands::Install::Linker::Classic
       package_dep = package.dependencies.try(&.[dependency.name]?) || package.optional_dependencies.try(&.[dependency.name]?)
       if package_dep
         version = package_dep.is_a?(String) ? package_dep : package_dep.version
-        return HoistAction::Stop unless Semver.parse?(version).try &.satisfies?(dependency.version)
+        return HoistAction::Stop unless linker.parse_range?(version).try &.satisfies?(dependency.version)
       end
 
       # stop hoisting if the package at the current location has a peer dependency but the version of dependency is not compatible
       package_peer = package.peer_dependencies.try(&.[dependency.name]?)
       if package_peer
         version = package_peer.is_a?(String) ? package_peer : package_peer.version
-        return HoistAction::Stop unless Semver.parse?(version).try &.satisfies?(dependency.version)
+        return HoistAction::Stop unless linker.parse_range?(version).try &.satisfies?(dependency.version)
       end
 
       # stop hoisting if the dependency has a peer dependency on package, no matter the version
@@ -148,7 +148,7 @@ class Commands::Install::Linker::Classic
       # dependency has a peer dependency on a previous hoisted dependency, but the version is not compatible
       dependency.peer_dependencies.try &.each do |peer_name, peer_version|
         hoisted = location.value.hoisted_packages[peer_name]?
-        compatible = !hoisted || Semver.parse?(peer_version).try &.satisfies?(hoisted.version)
+        compatible = !hoisted || linker.parse_range?(peer_version).try &.satisfies?(hoisted.version)
         return HoistAction::Stop unless compatible
       end
 

--- a/packages/commands/install/linker/linker.cr
+++ b/packages/commands/install/linker/linker.cr
@@ -1,6 +1,7 @@
 require "log"
 require "data/package"
 require "../state"
+require "concurrency/data_structures/safe_hash"
 
 module Commands::Install::Linker
   Log = ::Log.for("zap.commands.install.linker")
@@ -12,9 +13,33 @@ module Commands::Install::Linker
 
     alias Ancestors = Deque(Data::Package | Data::Lockfile::Root)
 
+    # Memoized semver range parses: the placement walk re-parses the same
+    # declared ranges once per visit per ancestor, and parsing dominates
+    # the walk's CPU cost. The parses are pure, so caching them cannot
+    # change the outcome; failed parses are cached as nil, so an invalid
+    # range is not re-parsed either. The walk runs on the worker pool, so
+    # the cache is thread-safe. (The version side of a satisfaction check
+    # is left to Range#satisfies?, which parses and tolerates invalid
+    # input.)
+    @range_cache = Concurrency::SafeHash(String, Semver::Range?).new
+
     def initialize(state : Commands::Install::State)
       @state = state
       @main_package = state.main_package
+    end
+
+    # The parsed range of *range*, parsed once per install; failed parses
+    # are cached as nil, so an invalid range is not re-parsed either.
+    protected def parse_range?(range : String) : Semver::Range?
+      if @range_cache.has_key?(range)
+        @range_cache[range]
+      elsif parsed = Semver.parse?(range)
+        @range_cache[range] = parsed
+        parsed
+      else
+        @range_cache[range] = nil
+        nil
+      end
     end
 
     abstract def install : Nil
@@ -118,7 +143,7 @@ module Commands::Install::Linker
       if peer_range.starts_with?("catalog:")
         peer_range = Commands::Install::Protocol::Catalog.expand(name, peer_range, state)
       end
-      range = Semver.parse?(peer_range) || Semver::ANY
+      range = parse_range?(peer_range) || Semver::ANY
       satisfied = false
       ancestors.each do |ancestor|
         ancestor.each_dependency do |ancestor_name, version_or_alias, _|
@@ -146,7 +171,7 @@ module Commands::Install::Linker
             peer_range = Commands::Install::Protocol::Catalog.expand(direct_peer, peer_range, state)
           end
           peers[direct_peer] = Set(Semver::Range){
-            Semver.parse?(peer_range).or(Semver::ANY),
+            parse_range?(peer_range).or(Semver::ANY),
           }
         end
       end

--- a/packages/commands/install/manifest.cr
+++ b/packages/commands/install/manifest.cr
@@ -1,15 +1,29 @@
 require "json"
-require "msgpack"
 require "semver"
 
 struct Commands::Install::Manifest
   include JSON::Serializable
-  include MessagePack::Serializable
+
+  # The on-disk cache format: a compact header (the dist-tags, the publish
+  # times and the versions sorted descending) followed by the raw JSON of
+  # every version. Loading reads only the header; a version's raw metadata
+  # is read on demand (one seek per selected version), so an install never
+  # deserializes the whole packument (measured: ~360ms for 164MB of cached
+  # packuments on every install).
+  CACHE_MAGIC   = 0x5A4D414E_u32 # "ZMAN"
+  CACHE_VERSION = 1_u16
 
   getter dist_tags : Hash(String, String) = Hash(String, String).new
-  getter versions_json : Hash(String, String) = Hash(String, String).new
   getter versions : Array(String) = Array(String).new
   getter times : Hash(String, String) = Hash(String, String).new
+  # The raw JSON of every version; only populated when the manifest was
+  # freshly parsed from the registry (the cache loads lazily instead).
+  getter versions_json : Hash(String, String) = Hash(String, String).new
+
+  # The on-disk cache file and the byte range of each version's raw JSON
+  # inside it, for the lazy reads.
+  @cache_path : Path? = nil
+  @cache_offsets : Hash(String, {Int32, Int32})? = nil
 
   def initialize(manifest_string : String | IO)
     @dist_tags = Hash(String, String).new
@@ -56,8 +70,20 @@ struct Commands::Install::Manifest
       end
     end
 
-    # sort by biggest version first
-    @versions.sort! { |a, b| Semver::Version.parse(b) <=> Semver::Version.parse(a) }
+    # sort by biggest version first, parsing each version once (the
+    # previous comparator-based sort parsed on every comparison)
+    @versions.sort_by! { |v| Semver::Version.parse(v) }
+    @versions.reverse!
+  end
+
+  private def initialize(
+    @dist_tags : Hash(String, String),
+    @versions : Array(String),
+    @times : Hash(String, String),
+    @versions_json : Hash(String, String),
+    @cache_path : Path?,
+    @cache_offsets : Hash(String, {Int32, Int32})?,
+  )
   end
 
   # The publish time of a version, from the packument's top-level `time`
@@ -74,7 +100,7 @@ struct Commands::Install::Manifest
   # published with a publisher signature and/or a provenance attestation.
   # Returns nil when the raw metadata is missing or unparseable.
   def dist_evidence?(version : String) : {Bool, Bool}?
-    raw = @versions_json[version]?
+    raw = raw_metadata(version)
     return unless raw
     dist = JSON.parse(raw).as_h["dist"]?.try(&.as_h)
     return unless dist
@@ -86,34 +112,115 @@ struct Commands::Install::Manifest
   end
 
   def get_raw_metadata?(version : Semver::Range | String) : String?
-    raw_metadata = nil
+    result = nil
 
     case version
     in String
       # Find the version that matches the dist-tag
       tag_version = dist_tags[version]?
-      raw_metadata = @versions_json[tag_version]? if tag_version
+      result = raw_metadata(tag_version) if tag_version
     in Semver::Range
       if version.exact_match?
         # For exact comparisons - we compare the version string
-        raw_metadata = @versions_json[version.to_s]?
+        result = raw_metadata(version.to_s)
       else
         # For range comparisons - take the highest version that matches the range
         highest_matching_version = @versions.find { |v| version.satisfies?(v) }
-        raw_metadata = @versions_json[highest_matching_version]? if highest_matching_version
-
-        # matching_version, json = @versions_json.reduce({nil, nil}) { |acc, (key, value)|
-        #   stored_semver, _ = acc
-        #   semver = Semver::Version.parse(key)
-        #   if (stored_semver.nil? || stored_semver < semver) && version.satisfies?(key)
-        #     next {semver, value}
-        #   end
-        #   acc
-        # }
-        # raw_metadata = json
+        result = raw_metadata(highest_matching_version) if highest_matching_version
       end
     end
 
-    raw_metadata
+    result
+  end
+
+  # The raw JSON of *version*, from the freshly parsed packument or, for a
+  # cache-loaded manifest, from the on-disk cache (one seek per version).
+  private def raw_metadata(version : String) : String?
+    @versions_json[version]? || read_cached_raw(version)
+  end
+
+  private def read_cached_raw(version : String) : String?
+    return unless path = @cache_path
+    offset_len = @cache_offsets.try &.[version]?
+    return unless offset_len
+    offset, len = offset_len
+    ::File.open(path) do |file|
+      file.seek(offset)
+      file.read_string(len)
+    end
+  rescue
+    # The cache file was evicted, truncated or replaced since the load; a
+    # nil metadata is treated as a resolution failure by the caller, like
+    # the load-time format errors.
+    nil
+  end
+
+  # Serializes the manifest into the on-disk cache format. A manifest that
+  # was itself loaded from the cache (a HEAD-revalidation re-set) carries
+  # no per-version JSON: the existing cache file is copied verbatim.
+  def write_cache(io : IO) : Nil
+    if path = @cache_path
+      ::File.open(path) { |file| IO.copy(file, io) }
+      return
+    end
+    io.write_bytes(CACHE_MAGIC, IO::ByteFormat::BigEndian)
+    io.write_bytes(CACHE_VERSION, IO::ByteFormat::BigEndian)
+    write_string_map(io, @dist_tags)
+    write_string_map(io, @times)
+    io.write_bytes(@versions.size.to_u32, IO::ByteFormat::BigEndian)
+    @versions.each do |version|
+      write_cache_string(io, version)
+      raw = @versions_json[version]? || ""
+      io.write_bytes(raw.bytesize.to_u32, IO::ByteFormat::BigEndian)
+      io.print(raw)
+    end
+  end
+
+  # Loads the header of the on-disk cache format; the raw per-version JSON
+  # blobs are skipped and read on demand from *path*.
+  def self.load_cache(path : Path, io : IO) : Manifest
+    raise "Invalid manifest cache (bad magic)" unless io.read_bytes(UInt32, IO::ByteFormat::BigEndian) == CACHE_MAGIC
+    raise "Unsupported manifest cache version" unless io.read_bytes(UInt16, IO::ByteFormat::BigEndian) == CACHE_VERSION
+    dist_tags = read_string_map(io)
+    times = read_string_map(io)
+    count = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
+    versions = Array(String).new(count)
+    offsets = Hash(String, {Int32, Int32}).new
+    count.times do
+      version = read_cache_string(io)
+      len = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
+      offsets[version] = {io.pos.to_i32, len.to_i32}
+      io.skip(len)
+      versions << version
+    end
+    new(dist_tags, versions, times, Hash(String, String).new, path, offsets)
+  end
+
+  private def write_string_map(io : IO, map : Hash(String, String)) : Nil
+    io.write_bytes(map.size.to_u16, IO::ByteFormat::BigEndian)
+    map.each do |key, value|
+      write_cache_string(io, key)
+      write_cache_string(io, value)
+    end
+  end
+
+  private def self.read_string_map(io : IO) : Hash(String, String)
+    count = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+    map = Hash(String, String).new(initial_capacity: count)
+    count.times do
+      key = read_cache_string(io)
+      map[key] = read_cache_string(io)
+    end
+    map
+  end
+
+  private def write_cache_string(io : IO, value : String) : Nil
+    io.write_bytes(value.bytesize.to_u16, IO::ByteFormat::BigEndian)
+    io.print(value)
+  end
+
+  private def self.read_cache_string(io : IO) : String
+    len = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+    io.read_string(len)
   end
 end

--- a/packages/commands/install/manifest.cr
+++ b/packages/commands/install/manifest.cr
@@ -4,6 +4,13 @@ require "semver"
 struct Commands::Install::Manifest
   include JSON::Serializable
 
+  # Raised when a cache body is not in the expected format (an older cache
+  # format version, or a corrupted/foreign file). The serializer treats it
+  # as a cache miss so the caller re-fetches, instead of failing the
+  # install or requiring a cache directory bump.
+  class CacheFormatError < Exception
+  end
+
   # The on-disk cache format: a compact header (the dist-tags, the publish
   # times and the versions sorted descending) followed by the raw JSON of
   # every version. Loading reads only the header; a version's raw metadata
@@ -179,8 +186,8 @@ struct Commands::Install::Manifest
   # Loads the header of the on-disk cache format; the raw per-version JSON
   # blobs are skipped and read on demand from *path*.
   def self.load_cache(path : Path, io : IO) : Manifest
-    raise "Invalid manifest cache (bad magic)" unless io.read_bytes(UInt32, IO::ByteFormat::BigEndian) == CACHE_MAGIC
-    raise "Unsupported manifest cache version" unless io.read_bytes(UInt16, IO::ByteFormat::BigEndian) == CACHE_VERSION
+    raise CacheFormatError.new("Invalid manifest cache (bad magic)") unless io.read_bytes(UInt32, IO::ByteFormat::BigEndian) == CACHE_MAGIC
+    raise CacheFormatError.new("Unsupported manifest cache version") unless io.read_bytes(UInt16, IO::ByteFormat::BigEndian) == CACHE_VERSION
     dist_tags = read_string_map(io)
     times = read_string_map(io)
     count = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)

--- a/packages/commands/install/manifest.cr
+++ b/packages/commands/install/manifest.cr
@@ -22,15 +22,17 @@ struct Commands::Install::Manifest
 
   getter dist_tags : Hash(String, String) = Hash(String, String).new
   getter versions : Array(String) = Array(String).new
-  getter times : Hash(String, String) = Hash(String, String).new
   # The raw JSON of every version; only populated when the manifest was
   # freshly parsed from the registry (the cache loads lazily instead).
   getter versions_json : Hash(String, String) = Hash(String, String).new
 
   # The on-disk cache file and the byte range of each version's raw JSON
-  # inside it, for the lazy reads.
+  # inside it, for the lazy reads. The publish times are stored the same
+  # way and read on demand: only the selected version's time is ever
+  # consulted, so the load skips the whole time-value section.
   @cache_path : Path? = nil
   @cache_offsets : Hash(String, {Int32, Int32})? = nil
+  @times_offsets : Hash(String, {Int32, Int32})? = nil
 
   def initialize(manifest_string : String | IO)
     @dist_tags = Hash(String, String).new
@@ -90,16 +92,34 @@ struct Commands::Install::Manifest
     @versions_json : Hash(String, String),
     @cache_path : Path?,
     @cache_offsets : Hash(String, {Int32, Int32})?,
+    @times_offsets : Hash(String, {Int32, Int32})?,
   )
   end
 
   # The publish time of a version, from the packument's top-level `time`
   # field. Returns nil when the registry does not expose it.
   def publish_time?(version : String) : Time?
-    raw = @times[version]?
+    raw = if offsets = @times_offsets
+      read_cached_time(version, offsets)
+    else
+      @times[version]?
+    end
     return unless raw
     Time.parse_iso8601(raw)
   rescue
+    nil
+  end
+
+  private def read_cached_time(version : String, offsets : Hash(String, {Int32, Int32})) : String?
+    return unless path = @cache_path
+    offset_len = offsets[version]?
+    return unless offset_len
+    offset, len = offset_len
+    ::File.open(path) do |file|
+      file.seek(offset)
+      file.read_string(len)
+    end
+  rescue ::File::NotFoundError
     nil
   end
 
@@ -189,7 +209,9 @@ struct Commands::Install::Manifest
     raise CacheFormatError.new("Invalid manifest cache (bad magic)") unless io.read_bytes(UInt32, IO::ByteFormat::BigEndian) == CACHE_MAGIC
     raise CacheFormatError.new("Unsupported manifest cache version") unless io.read_bytes(UInt16, IO::ByteFormat::BigEndian) == CACHE_VERSION
     dist_tags = read_string_map(io)
-    times = read_string_map(io)
+    # The time values are skipped: the keys and their byte offsets are kept
+    # and the selected version's value is read on demand.
+    times_offsets = read_string_offsets(io)
     count = io.read_bytes(UInt32, IO::ByteFormat::BigEndian)
     versions = Array(String).new(count)
     offsets = Hash(String, {Int32, Int32}).new
@@ -200,7 +222,7 @@ struct Commands::Install::Manifest
       io.skip(len)
       versions << version
     end
-    new(dist_tags, versions, times, Hash(String, String).new, path, offsets)
+    new(dist_tags, versions, Hash(String, String).new, Hash(String, String).new, path, offsets, times_offsets)
   end
 
   private def write_string_map(io : IO, map : Hash(String, String)) : Nil
@@ -217,6 +239,20 @@ struct Commands::Install::Manifest
     count.times do
       key = read_cache_string(io)
       map[key] = read_cache_string(io)
+    end
+    map
+  end
+
+  # Reads a string map's keys and records the byte range of each value
+  # without materializing it (the lazy publish times).
+  private def self.read_string_offsets(io : IO) : Hash(String, {Int32, Int32})
+    count = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+    map = Hash(String, {Int32, Int32}).new(initial_capacity: count)
+    count.times do
+      key = read_cache_string(io)
+      len = io.read_bytes(UInt16, IO::ByteFormat::BigEndian)
+      map[key] = {io.pos.to_i32, len.to_i32}
+      io.skip(len)
     end
     map
   end

--- a/packages/commands/install/manifest.cr
+++ b/packages/commands/install/manifest.cr
@@ -118,26 +118,26 @@ struct Commands::Install::Manifest
     nil
   end
 
-  def get_raw_metadata?(version : Semver::Range | String) : String?
-    result = nil
-
+  # The version string selected by *version* (a dist-tag, an exact version
+  # or a range), or nil when nothing matches.
+  def select_version(version : Semver::Range | String) : String?
     case version
     in String
       # Find the version that matches the dist-tag
-      tag_version = dist_tags[version]?
-      result = raw_metadata(tag_version) if tag_version
+      dist_tags[version]?
     in Semver::Range
       if version.exact_match?
         # For exact comparisons - we compare the version string
-        result = raw_metadata(version.to_s)
+        version.to_s
       else
         # For range comparisons - take the highest version that matches the range
-        highest_matching_version = @versions.find { |v| version.satisfies?(v) }
-        result = raw_metadata(highest_matching_version) if highest_matching_version
+        @versions.find { |v| version.satisfies?(v) }
       end
     end
+  end
 
-    result
+  def get_raw_metadata?(version : Semver::Range | String) : String?
+    select_version(version).try { |v| raw_metadata(v) }
   end
 
   # The raw JSON of *version*, from the freshly parsed packument or, for a

--- a/packages/commands/install/protocol/registry/resolver.cr
+++ b/packages/commands/install/protocol/registry/resolver.cr
@@ -260,11 +260,24 @@ struct Commands::Install::Protocol::Registry::Resolver < Commands::Install::Prot
         else
           self.specifier
         end
-      raw_metadata = manifest.get_raw_metadata?(version_for_selection)
-      unless raw_metadata
+      selected_version = manifest.select_version(version_for_selection)
+      unless selected_version
         raise "No version matching range or dist-tag #{specifier} for package #{@name} found in the module registry"
       end
-      pkg = Data::Package.from_json(raw_metadata)
+      # A per-version package cache: the msgpack roundtrip is far cheaper
+      # than re-reading the raw packument JSON and parsing it (~20KB per
+      # package). The manifest's own staleness still gates the resolve, so
+      # this cannot outlive the packument data it was built from.
+      cache_key = "#{@base_url.to_s}/#{@package_name}@#{selected_version}"
+      pkg = @skip_cache ? nil : @clients.package_cache.get(cache_key)
+      unless pkg
+        raw_metadata = manifest.get_raw_metadata?(version_for_selection)
+        unless raw_metadata
+          raise "No version matching range or dist-tag #{specifier} for package #{@name} found in the module registry"
+        end
+        pkg = Data::Package.from_json(raw_metadata)
+        @clients.package_cache.set(cache_key, pkg, 30.days) unless @skip_cache
+      end
       # Record the named registry on the resolved dist so the lockfile key
       # becomes registry-qualified (pnpm parity) and the package cannot be
       # quietly substituted by another registry publishing the same version.

--- a/packages/commands/install/registry_clients.cr
+++ b/packages/commands/install/registry_clients.cr
@@ -7,6 +7,23 @@ require "concurrency/mutex"
 #
 # The pools are lazily initialized and cached.
 class Commands::Install::RegistryClients
+  # The on-disk cache serializer for Manifests: the custom index format
+  # (see Manifest#write_cache / Manifest.load_cache). Loading only reads
+  # the header; the raw per-version JSON is read on demand from the cache
+  # file, so an install never deserializes the whole packument.
+  private struct ManifestCacheSerializer < Fetch::Cache::InStore::Serializer(Manifest)
+    def serialize(value : Manifest) : Bytes | String | IO
+      io = IO::Memory.new
+      value.write_cache(io)
+      # Bytes, not the IO: the memory's position sits at the end after the
+      # writes, and File.write(path, io) would copy nothing.
+      io.to_slice
+    end
+
+    def deserialize(value : IO, path : Path) : Manifest
+      Manifest.load_cache(path, value)
+    end
+  end
   # The pool of clients for each registry
   alias Pool = Fetch(Manifest, Fetch::HTTP1Transport) | Fetch::HTTP2(Manifest)
   @@client_pool_by_registry : Hash(String, Pool) = Hash(String, Pool).new
@@ -75,7 +92,7 @@ class Commands::Install::RegistryClients
     filesystem_cache = Fetch::Cache::InStore(Manifest).new(
       @store_path,
       bypass_staleness_checks: bypass_staleness_checks,
-      serializer: Fetch::Cache::InStore::MessagePackSerializer(Manifest).new
+      serializer: ManifestCacheSerializer.new
     )
 
     # The npmrc authentication for *base_url*: the config keys keep the

--- a/packages/commands/install/registry_clients.cr
+++ b/packages/commands/install/registry_clients.cr
@@ -2,6 +2,7 @@ require "./manifest"
 require "fetch"
 require "fetch/http2"
 require "concurrency/mutex"
+require "data/package"
 
 # Exposes a pool of http(s) clients for each registry and convenience methods to access the pools.
 #
@@ -30,6 +31,22 @@ class Commands::Install::RegistryClients
       nil
     end
   end
+
+  # The on-disk cache serializer for the resolved packages: the msgpack
+  # roundtrip is far cheaper than the raw packument JSON parse. A corrupted
+  # body degrades to a miss (the caller re-resolves) instead of failing the
+  # install, like the manifest cache.
+  private struct PackageCacheSerializer < Fetch::Cache::InStore::Serializer(Data::Package)
+    def serialize(value : Data::Package) : Bytes | String | IO
+      value.to_msgpack
+    end
+
+    def deserialize(value : IO, path : Path) : Data::Package?
+      Data::Package.from_msgpack(value)
+    rescue
+      nil
+    end
+  end
   # The pool of clients for each registry
   alias Pool = Fetch(Manifest, Fetch::HTTP1Transport) | Fetch::HTTP2(Manifest)
   @@client_pool_by_registry : Hash(String, Pool) = Hash(String, Pool).new
@@ -49,7 +66,19 @@ class Commands::Install::RegistryClients
     @bypass_staleness_checks : Bool = false,
     @network_protocol : String? = nil,
   )
+    @package_cache = Fetch::Cache::InStore(Data::Package).new(
+      @store_path,
+      bypass_staleness_checks: @bypass_staleness_checks,
+      serializer: PackageCacheSerializer.new
+    )
   end
+
+  # The per-version resolved-package cache shared by every registry pool:
+  # the msgpack roundtrip is far cheaper than parsing the raw packument
+  # JSON again on the next install. The key embeds the registry url, and
+  # the manifest cache's own staleness still gates every resolve, so the
+  # cache cannot outlive the packument data it was built from.
+  getter package_cache : Fetch::Cache::InStore(Data::Package)
 
   # Closes every client pool. Called once the CLI command has finished;
   # a no-op when no install ever created a pool.

--- a/packages/commands/install/registry_clients.cr
+++ b/packages/commands/install/registry_clients.cr
@@ -20,8 +20,14 @@ class Commands::Install::RegistryClients
       io.to_slice
     end
 
-    def deserialize(value : IO, path : Path) : Manifest
+    def deserialize(value : IO, path : Path) : Manifest?
       Manifest.load_cache(path, value)
+    rescue
+      # An unreadable body - an older cache format, a truncated or
+      # corrupted file - reports a miss so the caller re-fetches. The
+      # format version lives in the body header, so future format changes
+      # need no cache directory bump.
+      nil
     end
   end
   # The pool of clients for each registry

--- a/packages/commands/spec/install/integration/command_execution._spec.cr
+++ b/packages/commands/spec/install/integration/command_execution._spec.cr
@@ -32,7 +32,7 @@ describe "command execution", tags: "integration" do
         File.exists?(project / ".pnp.loader.mjs").should be_true
         # No packages are linked into node_modules; only the .pnp data dir
         # (and the installed-state file)
-        Dir.children(project / "node_modules").sort.should eq([".pnp", ".zap-state"])
+        Dir.children(project / "node_modules").sort.should eq([".pnp", ".zap-fingerprint", ".zap-state"])
       end
     end
   end

--- a/packages/commands/spec/install/integration/fast_path._spec.cr
+++ b/packages/commands/spec/install/integration/fast_path._spec.cr
@@ -1,0 +1,146 @@
+require "./spec_helper"
+
+# The up-to-date fast path (issue #48): when nothing relevant changed since
+# the last completed install, the install pass is skipped entirely.
+describe "fast path", tags: "integration" do
+  it "skips the install pass when nothing changed" do
+    It.with_registry do |registry|
+      registry.add("fresh", "1.2.3", It.pkg("fresh", "1.2.3"), {"index.js" => "f"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"fresh":"1.2.3"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, check_resolutions: false)
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile_mtime = File.info(tmpdir / "zap.lock").modification_time
+        file_mtime = File.info(tmpdir / "node_modules/fresh/index.js").modification_time
+        state_mtime = File.info(tmpdir / "node_modules/.zap-state").modification_time
+        fingerprint = File.read(tmpdir / "node_modules/.zap-fingerprint")
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.info(tmpdir / "zap.lock").modification_time.should eq(lockfile_mtime)
+        File.info(tmpdir / "node_modules/fresh/index.js").modification_time.should eq(file_mtime)
+        File.info(tmpdir / "node_modules/.zap-state").modification_time.should eq(state_mtime)
+        File.read(tmpdir / "node_modules/.zap-fingerprint").should eq(fingerprint)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "re-runs the install pass when package.json changed" do
+    It.with_registry do |registry|
+      registry.add("fresh", "1.2.3", It.pkg("fresh", "1.2.3"), {"index.js" => "f"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"fresh":"1.2.3"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, check_resolutions: false)
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile_mtime = File.info(tmpdir / "zap.lock").modification_time
+        sleep 10.milliseconds
+
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"fresh":"^1.0.0"}}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.info(tmpdir / "zap.lock").modification_time.should_not eq(lockfile_mtime)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "re-runs the install pass when a workspace member changed" do
+    It.with_registry do |registry|
+      ws_root = Path.new(Dir.tempdir, "zap-ws-test-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(ws_root / "packages/a")
+        Dir.mkdir_p(ws_root / "packages/b")
+        File.write(ws_root / "package.json", %({"name":"ws-root","version":"1.0.0","workspaces":["packages/*"]}))
+        File.write(ws_root / ".npmrc", "registry=#{registry.base_url}/\n")
+        File.write(ws_root / "packages/a/package.json", %({"name":"ws-a","version":"1.0.0","main":"index.js"}))
+        File.write(ws_root / "packages/a/index.js", "ws-a")
+        File.write(ws_root / "packages/b/package.json", %({"name":"ws-b","version":"1.0.0"}))
+        File.write(ws_root / "packages/b/index.js", "ws-b")
+
+        config = Core::Config.new.copy_with(prefix: ws_root.to_s, store_path: (ws_root / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, check_resolutions: false)
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        lockfile_mtime = File.info(ws_root / "zap.lock").modification_time
+        sleep 10.milliseconds
+
+        File.write(ws_root / "packages/b/package.json", %({"name":"ws-b","version":"2.0.0"}))
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.info(ws_root / "zap.lock").modification_time.should_not eq(lockfile_mtime)
+      ensure
+        FileUtils.rm_rf(ws_root)
+      end
+    end
+  end
+
+  it "re-runs the install pass when the lockfile was edited" do
+    It.with_registry do |registry|
+      registry.add("fresh", "1.2.3", It.pkg("fresh", "1.2.3"), {"index.js" => "f"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"fresh":"1.2.3"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, check_resolutions: false)
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        lockfile = tmpdir / "zap.lock"
+        lockfile_mtime = File.info(lockfile).modification_time
+        # A manual edit (even a whitespace-only one) must invalidate the
+        # fast path: the next install re-resolves and rewrites the lockfile
+        # instead of silently keeping the old tree.
+        File.write(lockfile, File.read(lockfile) + "\n")
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.info(lockfile).modification_time.should_not eq(lockfile_mtime)
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+
+  it "re-runs the install pass when the lockfile is missing" do
+    It.with_registry do |registry|
+      registry.add("fresh", "1.2.3", It.pkg("fresh", "1.2.3"), {"index.js" => "f"})
+
+      tmpdir = Path.new(Dir.tempdir, "zap-it-#{Random::Secure.hex(4)}")
+      begin
+        Dir.mkdir_p(tmpdir)
+        File.write(tmpdir / "package.json", %({"name":"app","version":"1.0.0","dependencies":{"fresh":"1.2.3"}}))
+        File.write(tmpdir / ".npmrc", "registry=#{registry.base_url}/\n")
+        config = Core::Config.new.copy_with(prefix: tmpdir.to_s, store_path: (tmpdir / "store").to_s, silent: true)
+        ic = Commands::Install::Config.new.copy_with(workers: 1, frozen_lockfile: false, check_resolutions: false)
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+        File.delete(tmpdir / "zap.lock")
+
+        Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
+
+        File.exists?(tmpdir / "zap.lock").should be_true
+      ensure
+        FileUtils.rm_rf(tmpdir)
+      end
+    end
+  end
+end

--- a/packages/commands/spec/install/integration/workspace_filters._spec.cr
+++ b/packages/commands/spec/install/integration/workspace_filters._spec.cr
@@ -131,7 +131,7 @@ describe "workspace filters", tags: "integration" do
         Commands::Install.run(config, ic, raise_on_failure: true, reporter: Reporter::Null.new)
 
         File.exists?(ws_root / ".pnp.cjs").should be_true
-        Dir.children(ws_root / "node_modules").sort.should eq([".pnp", ".zap-state"])
+        Dir.children(ws_root / "node_modules").sort.should eq([".pnp", ".zap-fingerprint", ".zap-state"])
       ensure
         FileUtils.rm_rf(ws_root)
       end

--- a/packages/concurrency/pipeline.cr
+++ b/packages/concurrency/pipeline.cr
@@ -3,9 +3,7 @@ require "./data_structures/safe_array"
 class Concurrency::Pipeline
   getter counter = Atomic(Int32).new(0)
   @errors = SafeArray(Exception).new
-  @end_channel = Channel(SafeArray(Exception)?).new(1)
   @max_fibers_channel : Channel(Nil)? = nil
-  @closing = Atomic(Int32).new(0)
   @execution_context : Fiber::ExecutionContext
 
   def initialize(*, workers : Int32 = 1)
@@ -20,11 +18,8 @@ class Concurrency::Pipeline
   def reset
     @counter = Atomic(Int32).new(0)
     @errors = SafeArray(Exception).new
-    @end_channel.close unless @end_channel.closed?
-    @end_channel = Channel(SafeArray(Exception)?).new(1)
     @max_fibers_channel.try { |c| c.close unless c.closed? }
     @max_fibers_channel = nil
-    @closing = Atomic(Int32).new(0)
   end
 
   def set_concurrency(max_fibers : Int32 | Nil)
@@ -54,13 +49,6 @@ class Concurrency::Pipeline
 
   def process(&block)
     return if @errors.size > 0
-    # Starting a fresh phase on a reused pipeline: the previous phase's last
-    # fiber closed the end channel, so give the new fibers a channel to
-    # deliver their results to.
-    if @counter.get == 0 && @end_channel.closed?
-      @end_channel = Channel(SafeArray(Exception)?).new(1)
-      @closing = Atomic(Int32).new(0)
-    end
     @counter.add(1)
     @execution_context.spawn do
       check_max_fibers do
@@ -71,12 +59,7 @@ class Concurrency::Pipeline
       rescue ex
         @errors << ex
       ensure
-        counter = @counter.sub(1)
-        # Use atomic swap to ensure only one fiber closes the channel
-        if counter <= 1 && @closing.swap(1) == 0 && !@end_channel.closed?
-          @end_channel.send(@errors) if @errors.size > 0
-          @end_channel.close
-        end
+        @counter.sub(1)
       end
     end
   end
@@ -87,15 +70,23 @@ class Concurrency::Pipeline
     end
   end
 
-  def await(*, force_wait = false)
+  # Blocks until every fiber dispatched with `process` has completed, then
+  # raises if any of them failed. The caller parks on a short timer instead
+  # of spinning: the periodic wakeups keep it runnable so the scheduler can
+  # run fibers dispatched from other fibers (a fully blocked caller would
+  # stall them - the nested dependency resolution only runs while the
+  # caller yields), and the counter - not a channel - decides completion.
+  def await
     Fiber.yield
-    # The error array is populated before the fiber's ensure runs, so a
-    # raise that lands between @counter.sub and the end-channel send is
-    # still visible here (the channel alone would race: counter 0 + the
-    # channel not yet closed).
-    if force_wait || @counter.get > 0 || @end_channel.closed? || @errors.size > 0
-      maybe_exceptions = @end_channel.receive?
-      raise PipelineException.new(maybe_exceptions) if maybe_exceptions
+    until @counter.get <= 0
+      sleep 1.millisecond
+    end
+    if @errors.size > 0
+      # Consume the phase's errors: a reused pipeline must start its next
+      # phase clean (the caller may catch the exception and keep going).
+      exceptions = @errors
+      @errors = SafeArray(Exception).new
+      raise PipelineException.new(exceptions)
     end
   end
 

--- a/packages/fetch/cache.cr
+++ b/packages/fetch/cache.cr
@@ -8,10 +8,10 @@ require "concurrency/data_structures/safe_hash"
 class Fetch(T, Transport)
   abstract class Cache(T)
     Log = ::Log.for("zap.fetch.cache")
-    # v2: the Manifest cache switched from a full msgpack payload to the
-    # index + lazy raw reads; the dir is bumped so stale v1 files (which
-    # fail the new decoder) are never read.
-    CACHE_DIR = ".fetch_cache_v2"
+    # The on-disk cache bodies are self-describing (magic + version in
+    # the header), so format mismatches degrade to misses and the
+    # directory name stays stable across format changes.
+    CACHE_DIR = ".fetch_cache"
 
     abstract def get(key_str : String, etag : String?) : T?
     abstract def get(key_str : String, &etag : -> String?) : T?
@@ -77,8 +77,10 @@ class Fetch(T, Transport)
       abstract struct Serializer(T)
         abstract def serialize(value : T) : Bytes | String | IO
         # *path* is the cache body file: a deserializer may keep it for
-        # lazy reads instead of decoding the whole payload.
-        abstract def deserialize(value : IO, path : Path) : T
+        # lazy reads instead of decoding the whole payload. Returns nil
+        # when the body is not in the expected format: the caller treats
+        # it as a cache miss and re-fetches.
+        abstract def deserialize(value : IO, path : Path) : T?
       end
 
       struct NoopSerializer < Serializer(String)

--- a/packages/fetch/cache.cr
+++ b/packages/fetch/cache.cr
@@ -8,7 +8,10 @@ require "concurrency/data_structures/safe_hash"
 class Fetch(T, Transport)
   abstract class Cache(T)
     Log = ::Log.for("zap.fetch.cache")
-    CACHE_DIR = ".fetch_cache"
+    # v2: the Manifest cache switched from a full msgpack payload to the
+    # index + lazy raw reads; the dir is bumped so stale v1 files (which
+    # fail the new decoder) are never read.
+    CACHE_DIR = ".fetch_cache_v2"
 
     abstract def get(key_str : String, etag : String?) : T?
     abstract def get(key_str : String, &etag : -> String?) : T?
@@ -73,7 +76,9 @@ class Fetch(T, Transport)
 
       abstract struct Serializer(T)
         abstract def serialize(value : T) : Bytes | String | IO
-        abstract def deserialize(value : IO) : T
+        # *path* is the cache body file: a deserializer may keep it for
+        # lazy reads instead of decoding the whole payload.
+        abstract def deserialize(value : IO, path : Path) : T
       end
 
       struct NoopSerializer < Serializer(String)
@@ -81,7 +86,7 @@ class Fetch(T, Transport)
           value
         end
 
-        def deserialize(value : IO) : String
+        def deserialize(value : IO, path : Path) : String
           value.gets_to_end
         end
       end
@@ -91,7 +96,7 @@ class Fetch(T, Transport)
           value.to_msgpack
         end
 
-        def deserialize(value : IO) : T
+        def deserialize(value : IO, path : Path) : T
           T.from_msgpack(value)
         end
       end
@@ -144,7 +149,7 @@ class Fetch(T, Transport)
           end
         }.try do |path|
           io = ::File.open(path)
-          @serializer.deserialize(io)
+          @serializer.deserialize(io, path)
         ensure
           io.try &.close
         end
@@ -180,7 +185,7 @@ class Fetch(T, Transport)
           end
         }.try do |path|
           io = ::File.open(path)
-          @serializer.deserialize(io)
+          @serializer.deserialize(io, path)
         ensure
           io.try &.close
         end

--- a/packages/fetch/cache.cr
+++ b/packages/fetch/cache.cr
@@ -197,9 +197,14 @@ class Fetch(T, Transport)
         key = self.class.hash(key_str)
         root_path = @path / key
         body_file_path = root_path / BODY_FILE_NAME
-        body_file_path_temp = root_path / BODY_FILE_NAME_TEMP
         meta_file_path = root_path / META_FILE_NAME
-        meta_file_path_temp = root_path / META_FILE_NAME_TEMP
+        # The temp names embed a per-write suffix: concurrent sets for the
+        # same key (two fibers resolving the same package) must not clobber
+        # each other's temps, or the second rename would fail with ENOENT.
+        # The final rename is atomic, so the last writer wins consistently.
+        suffix = "#{Process.pid}-#{Random::Secure.hex(4)}"
+        body_file_path_temp = root_path / "#{BODY_FILE_NAME_TEMP}.#{suffix}"
+        meta_file_path_temp = root_path / "#{META_FILE_NAME_TEMP}.#{suffix}"
         Log.debug { "(#{key_str}) Storing metadata at #{root_path}" }
         Utils::Directories.mkdir_p(root_path)
         ::File.write(body_file_path_temp, @serializer.serialize(value))

--- a/packages/http2/src/stream_data.cr
+++ b/packages/http2/src/stream_data.cr
@@ -2,8 +2,14 @@
 # the connection and closed at END_STREAM.
 module HTTP2
   class StreamData < IO
+    # The per-stream chunk buffer: 64 x 16 KiB frames (1 MiB) of slack
+    # before the connection fiber blocks on a slow consumer and stalls
+    # the connection's other streams (16 chunks made one slow stream gate
+    # the whole connection after 256 KiB of buffered data).
+    CHUNK_CAPACITY = 64
+
     def initialize
-      @chunks = Channel(Bytes).new(16)
+      @chunks = Channel(Bytes).new(CHUNK_CAPACITY)
       @pending = Bytes.empty
       @error = nil
     end

--- a/packages/utils/targzip.cr
+++ b/packages/utils/targzip.cr
@@ -12,8 +12,18 @@ module Utils::TarGzip
           # Strip the leading directory (usually "package/") and neutralize any
           # ".", ".." or empty component to prevent directory traversal
           # from malicious tarballs.
-          components = entry.name.split(/[\/\\]/)[1..-1].reject { |c| c == "." || c == ".." || c.empty? }
-          file_path = Path.new(components.join("/"))
+          name = entry.name
+          # Fast path: npm tarballs are "package/<path>" with no traversal,
+          # dot or empty components; the split/reject/join below allocates
+          # several objects per entry (~116k entries per cold install).
+          # Any suspicious component falls back to the full sanitization.
+          if name.starts_with?("package/") &&
+             !name.includes?("\\") && !name.includes?("..") && !name.includes?("/.") && !name.includes?("//")
+            file_path = Path.new(name.byte_slice(8))
+          else
+            components = name.split(/[\/\\]/)[1..-1].reject { |c| c == "." || c == ".." || c.empty? }
+            file_path = Path.new(components.join("/"))
+          end
           yield entry, file_path, entry.io
         end
       end


### PR DESCRIPTION
Fixes #48

## Summary

Twelve independent optimizations and correctness fixes for `zap i`, measured against the benchmark scenarios and the real-world ledger-live monorepo (16 712 resolutions, 122 workspaces).

### Fast path (issue #48)
- **Skip the install pass when nothing relevant changed**: a project fingerprint — scope package.jsons (path + content), `.npmrc`, install strategy, omit set, lockfile format **and content**, patch files, installed state — is recorded after a successful install. When it matches and every recorded path still exists, resolution/download/linking are skipped. Root lifecycle scripts still run (npm/yarn parity); `--check-resolutions` disables it.

### Caches
- **Lazy metadata cache**: packument cache stores a compact index (dist-tags, times, versions sorted once at fetch) + raw per-version JSON, read on demand. Measured 196ms vs 362ms for the full msgpack decode.
- **Lazy publish times**: the load skips the time values, reads the selected version's on demand (~25–33% faster loads).
- **Per-version resolved-package cache**: msgpack roundtrip replaces the ~20KB raw-JSON parse per selected package.
- **Self-describing cache format** (magic + version in the body): format mismatches and corruption degrade to misses (re-fetch) instead of failing the install; the directory name is stable — no more bumps.

### Concurrency
- **The pipeline await now actually waits** (fix): the old `receive?` returned as soon as the end channel closed (which happened at counter `<= 1`), so a mid-drain process could leave the counter above zero with the channel closed — the resolution could race the lockfile write and still-running fibers' errors were dropped. The new await parks on a 1ms timer (no spin, ~0 CPU) and drains the counter; the zero-close can't drop the completion signal; errors are consumed on raise so a reused pipeline starts clean. A plain blocking receive deadlocks with the current spawn structure (nested fibers only run while the caller yields) — reproduced with a deep-walk stress at 1 and 4 workers.
- **Unique temp names for concurrent InStore cache writes** (fix): two fibers resolving the same package clobbered the shared temps and the second rename failed ENOENT, surfacing as random resolution errors. The final rename is atomic — last writer wins.
- **Default workers = min(4, max(1, cpu_count // 2))**: half the logical cores, capped at 4; measured ~30–35% faster cold installs.
- **Memoized semver range parses** in the placement walk (thread-safe, failed parses cached as nil).
- **Larger HTTP/2 per-stream chunk buffer** (16 → 64 frames): a slow stream no longer gates the whole connection after 256KiB.

### Misc
- **Tar entry path fast path**: npm tarballs slice directly instead of split/reject/join/Path; suspicious names fall back to the full sanitization (verified on a 14-case traversal matrix).
- **Bench**: pass `--check-resolutions=false` to the zap runs (CI parity).

## Verification
- Full suite 10/10 projects, e2e 10/10, integration 428/428, fast-path spec 5/5 (incl. tampered-lockfile case)
- Deep-walk stress 81/81 and ledger-scale walk (20 736 leaves) at workers 1 and 4
- Cold installs with complete trees at workers 1 and 4
- Real-world: ledger-live monorepo install (16 712 resolutions) completes

## Notes
- The `--check-resolutions` default under CI disables the fast path (its ref-walk needs a full resolution); benchmarks pass the flag explicitly for parity.
- The cache directory is `.fetch_cache` — the format is self-describing, so future format changes need no directory rename.
